### PR TITLE
Update gradle file to handle the way Jenkins views branches/main

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,7 +119,7 @@ subprojects {
     jar {
         processResources.exclude('checkstyle.xml')
         processResources.exclude('spotbugs-filter.xml')
-        classifier (!gitBranch().equalsIgnoreCase("main") ? "SNAPSHOT" : "")
+        classifier "main".equalsIgnoreCase(gitBranch()) || "main".equalsIgnoreCase(System.getenv('BRANCH_NAME')) ? "" : "SNAPSHOT"
         out.println("**** building branch - " + gitBranch() + ", classifier - " + classifier + " - CI branch - " + System.getenv('BRANCH_NAME'))
     }
 


### PR DESCRIPTION
Jenkins wasn't able to use git to view the name of the branch being checked out but it is stored in $BRANCH_NAME so tested against that too.

### What Does This PR Do?

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure