### PR TITLE
Shouldn't have put trimmer in filter

### DIFF
--- a/ab2d-filters/build.gradle
+++ b/ab2d-filters/build.gradle
@@ -2,7 +2,7 @@ configurations {
     spi
 }
 
-version '1.1'
+version '1.2'
 
 dependencies {
     // Move these dependencies to the individual libraries that need them if adding

--- a/ab2d-filters/src/main/java/gov/cms/ab2d/filter/FilterEob.java
+++ b/ab2d-filters/src/main/java/gov/cms/ab2d/filter/FilterEob.java
@@ -27,7 +27,7 @@ public final class FilterEob {
             return Optional.empty();
         }
         if (skipBillablePeriodCheck || FilterOutByDate.valid(resource, attTime, earliestDate, dateRanges)) {
-            return Optional.of(ExplanationOfBenefitTrimmer.getBenefit(resource));
+            return Optional.of(resource);
         }
         return Optional.empty();
     }


### PR DESCRIPTION
### What Does This PR Do?

When the trimmer was being used in a stream filter, the EOB isn't being replaced. The trimmer should be called later in the stream as a map. Also updated the library version. In the filter, it does nothing.

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

### Impacted External Components

### Database Changes

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure