### PR TITLE
Stopped removing links to procedures and diagnosis from the item

### DIFF
--- a/ab2d-filters/src/main/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerR4.java
+++ b/ab2d-filters/src/main/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerR4.java
@@ -221,14 +221,14 @@ public class ExplanationOfBenefitTrimmerR4 {
         /*
          Keep:
               sequence
+              diagnosisSequence
+              procedureSequence
               careTeamSequence
               productOrService
               serviced
               location
               quantity
          */
-        clearOutList(component.getDiagnosisSequence());
-        clearOutList(component.getProcedureSequence());
         clearOutList(component.getInformationSequence());
         component.setExtension(null);
         component.setRevenue(null);

--- a/ab2d-filters/src/main/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerSTU3.java
+++ b/ab2d-filters/src/main/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerSTU3.java
@@ -110,13 +110,13 @@ public class ExplanationOfBenefitTrimmerSTU3 {
          Keep:
               sequence
               careTeamLinkId
+              diagnosisLinkId
+              procedureLinkId
               service
               serviced
               location
               quantity
          */
-        clearOutList(component.getDiagnosisLinkId());
-        clearOutList(component.getProcedureLinkId());
         clearOutList(component.getInformationLinkId());
         component.setExtension(null);
         component.setRevenue(null);

--- a/ab2d-filters/src/test/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerR4Test.java
+++ b/ab2d-filters/src/test/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerR4Test.java
@@ -16,6 +16,7 @@ import org.hl7.fhir.r4.model.Narrative;
 import org.hl7.fhir.r4.model.Organization;
 import org.hl7.fhir.r4.model.Patient;
 import org.hl7.fhir.r4.model.Period;
+import org.hl7.fhir.r4.model.PositiveIntType;
 import org.hl7.fhir.r4.model.Reference;
 import org.hl7.fhir.r4.model.ServiceRequest;
 import org.hl7.fhir.r4.model.StringType;
@@ -94,7 +95,13 @@ public class ExplanationOfBenefitTrimmerR4Test {
         EOB.setUse(ExplanationOfBenefit.Use.CLAIM);
         EOB.setAdjudication(List.of(new ExplanationOfBenefit.AdjudicationComponent().setAmount(new Money().setValue(11))));
         EOB.setSupportingInfo(List.of(new ExplanationOfBenefit.SupportingInformationComponent().setSequence(3).setReason(new Coding().setCode("code"))));
-        EOB.setItem(List.of(new ExplanationOfBenefit.ItemComponent().setSequence(3).setCategory(new CodeableConcept().setText("category"))));
+        ExplanationOfBenefit.ItemComponent item = new ExplanationOfBenefit.ItemComponent()
+                .setSequence(3)
+                .setCategory(new CodeableConcept().setText("category"))
+                .setDiagnosisSequence(List.of(new PositiveIntType(1)))
+                .setCareTeamSequence(List.of(new PositiveIntType(2)))
+                .setProcedureSequence(List.of(new PositiveIntType(3)));
+        EOB.setItem(List.of(item));
         EOB.setIdentifier(List.of(new Identifier().setType(new CodeableConcept().setText("one")).setValue("value")));
         EOB.setStatus(ExplanationOfBenefit.ExplanationOfBenefitStatus.CANCELLED);
         EOB.setType(new CodeableConcept().setText(DUMMY_TYPE));
@@ -103,6 +110,7 @@ public class ExplanationOfBenefitTrimmerR4Test {
 
         EOB.setCareTeam(List.of(
                 new ExplanationOfBenefit.CareTeamComponent().setResponsible(true)
+                .setSequence(2)
                 .setRole(new CodeableConcept().setText("care"))
                 .setProvider(new Reference("provider"))
         ));
@@ -114,6 +122,7 @@ public class ExplanationOfBenefitTrimmerR4Test {
         ));
         EOB.setProcedure(List.of(
                 new ExplanationOfBenefit.ProcedureComponent()
+                .setSequence(3)
                 .setType(List.of(new CodeableConcept().setText(DUMMY_TYPE)))
                 .setUdi(List.of(new Reference("udi")))
                 .setProcedure(new CodeableConcept().setText("procedure"))
@@ -181,6 +190,9 @@ public class ExplanationOfBenefitTrimmerR4Test {
         assertNull(component.getCategory().getText());
         assertEquals(3, component.getSequence());
         assertEquals(1, eobtrim.getIdentifier().size());
+        assertEquals(2, component.getCareTeamSequence().get(0).getValue());
+        assertEquals(1, component.getDiagnosisSequence().get(0).getValue());
+        assertEquals(3, component.getProcedureSequence().get(0).getValue());
         Identifier id = eobtrim.getIdentifier().get(0);
         assertEquals("value", id.getValue());
         assertEquals("one", id.getType().getText());

--- a/ab2d-filters/src/test/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerSTU3Test.java
+++ b/ab2d-filters/src/test/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerSTU3Test.java
@@ -92,7 +92,8 @@ public class ExplanationOfBenefitTrimmerSTU3Test {
         ExplanationOfBenefit eobCarrier = (ExplanationOfBenefit) eobResource;
         if (eobCarrier.getItem() != null) {
             for (var item : eobCarrier.getItem()) {
-                assertTrue(isNullOrEmpty(item.getDiagnosisLinkId()));
+                assertFalse(isNullOrEmpty(item.getCareTeamLinkId()));
+                assertFalse(isNullOrEmpty(item.getDiagnosisLinkId()));
                 assertTrue(isNullOrEmpty(item.getProcedureLinkId()));
                 assertTrue(isNullOrEmpty(item.getInformationLinkId()));
                 assertNull(item.getRevenue().getId());

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ ext {
 
     fhirVersion='1.0'
     bfdVersion='1.0.1'
-    filtersVersion='1.2'
+    filtersVersion='1.3'
     commonsLangVersion='3.12.0'
 
     sourcesRepo = 'ab2d-maven-repo'


### PR DESCRIPTION
**JIRA Tickets:**
[AB2D-4481](https://jira.cms.gov/browse/AB2D-4481) - Update library in AB2D-Libs to remove filtering of diagnosis and procedure links

***Related Tickets:***
[AB2D-4465](https://jira.cms.gov/browse/AB2D-4465) - No longer filter out links to both STU3 and R4 EOBS

### What Does This PR Do?

In EOBs, items refer to top level care teams, diagnosis and procedures. We were providing the diagnosis and procedures, but not links in the item.

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

This is a new version of the library so anyone who is using this should upgrade to 1.3.

### Impacted External Components

### Database Changes

### Limitations

### Security Implications

This is technically more data but it's really just linking data inside of an EOB. It's in the process of being reviewed by CMS.

<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [X] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [X] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure