### PR TITLE
Update contract to contain approx enrollment numbers.

### DIFF
--- a/ab2d-contracts-client/src/main/java/gov/cms/ab2d/contracts/model/Contract.java
+++ b/ab2d-contracts-client/src/main/java/gov/cms/ab2d/contracts/model/Contract.java
@@ -65,13 +65,21 @@ public class Contract extends TimestampBase {
     @Enumerated(EnumType.STRING)
     private ContractType contractType = ContractType.NORMAL;
 
+    @Column(name = "total_enrollment")
+    private Integer totalEnrollment;
+
+    @Column(name = "medicare_eligible")
+    private Integer medicareEligible;
+
     public Contract(@NotNull String contractNumber, String contractName, Long hpmsParentOrgId, String hpmsParentOrg,
-                    String hpmsOrgMarketingName) {
+                    String hpmsOrgMarketingName, Integer totalEnrollment, Integer medicareEligible) {
         this.contractNumber = contractNumber;
         this.contractName = contractName;
         this.hpmsParentOrgId = hpmsParentOrgId;
         this.hpmsParentOrg = hpmsParentOrg;
         this.hpmsOrgMarketingName = hpmsOrgMarketingName;
+        this.totalEnrollment = totalEnrollment;
+        this.medicareEligible = medicareEligible;
     }
 
     @Column(columnDefinition = "TIMESTAMP WITH TIME ZONE")
@@ -89,20 +97,26 @@ public class Contract extends TimestampBase {
         attestedOn = null;
     }
 
-    public boolean hasChanges(String hmpsContractName, long parentOrgId, String parentOrgName, String orgMarketingName) {
+    public boolean hasChanges(String hmpsContractName, long parentOrgId, String parentOrgName, String orgMarketingName,
+                              Integer hpmsTotalEnrollment, Integer medicareEligible) {
         boolean allEqual = Objects.equals(hmpsContractName, contractName) &&
                 Objects.equals(parentOrgId, hpmsParentOrgId) &&
                 Objects.equals(parentOrgName, hpmsParentOrg) &&
-                Objects.equals(orgMarketingName, hpmsOrgMarketingName);
+                Objects.equals(orgMarketingName, hpmsOrgMarketingName) &&
+                Objects.equals(totalEnrollment, hpmsTotalEnrollment) &&
+                Objects.equals(medicareEligible, medicareEligible);
 
         return !allEqual;
     }
 
-    public Contract updateOrg(String hmpsContractName, long parentOrgId, String parentOrgName, String orgMarketingName) {
-        contractName = hmpsContractName;
-        hpmsParentOrgId = parentOrgId;
-        hpmsParentOrg = parentOrgName;
-        hpmsOrgMarketingName = orgMarketingName;
+    public Contract updateOrg(String hmpsContractName, long parentOrgId, String parentOrgName, String orgMarketingName,
+                              Integer hpmsTotalEnrollment, Integer hpmsMedicareEligible) {
+        this.contractName = hmpsContractName;
+        this.hpmsParentOrgId = parentOrgId;
+        this.hpmsParentOrg = parentOrgName;
+        this.hpmsOrgMarketingName = orgMarketingName;
+        this.totalEnrollment = hpmsTotalEnrollment;
+        this.medicareEligible = hpmsMedicareEligible;
         return this;
     }
 
@@ -139,9 +153,8 @@ public class Contract extends TimestampBase {
         return updateMode == UpdateMode.AUTOMATIC;
     }
 
-
     public ContractDTO toDTO() {
         return new ContractDTO(getId(), getContractNumber(), getContractName(),
-                getAttestedOn(), getContractType());
+                getAttestedOn(), getContractType(), getTotalEnrollment(), getMedicareEligible());
     }
 }

--- a/ab2d-contracts-client/src/main/java/gov/cms/ab2d/contracts/model/Contract.java
+++ b/ab2d-contracts-client/src/main/java/gov/cms/ab2d/contracts/model/Contract.java
@@ -98,13 +98,13 @@ public class Contract extends TimestampBase {
     }
 
     public boolean hasChanges(String hmpsContractName, long parentOrgId, String parentOrgName, String orgMarketingName,
-                              Integer hpmsTotalEnrollment, Integer medicareEligible) {
+                              Integer hpmsTotalEnrollment, Integer hpmsMedicareEligible) {
         boolean allEqual = Objects.equals(hmpsContractName, contractName) &&
                 Objects.equals(parentOrgId, hpmsParentOrgId) &&
                 Objects.equals(parentOrgName, hpmsParentOrg) &&
                 Objects.equals(orgMarketingName, hpmsOrgMarketingName) &&
                 Objects.equals(totalEnrollment, hpmsTotalEnrollment) &&
-                Objects.equals(medicareEligible, medicareEligible);
+                Objects.equals(medicareEligible, hpmsMedicareEligible);
 
         return !allEqual;
     }

--- a/ab2d-contracts-client/src/main/java/gov/cms/ab2d/contracts/model/ContractDTO.java
+++ b/ab2d-contracts-client/src/main/java/gov/cms/ab2d/contracts/model/ContractDTO.java
@@ -25,6 +25,10 @@ public class ContractDTO {
 
     private Contract.ContractType contractType;
 
+    private Integer totalEnrollment;
+
+    private Integer medicareEligible;
+
     public boolean hasDateIssue() {
         return Contract.ContractType.CLASSIC_TEST == contractType;
     }

--- a/ab2d-contracts-client/src/test/java/gov/cms/ab2d/contracts/utils/ContractTest.java
+++ b/ab2d-contracts-client/src/test/java/gov/cms/ab2d/contracts/utils/ContractTest.java
@@ -1,0 +1,132 @@
+package gov.cms.ab2d.contracts.utils;
+
+import gov.cms.ab2d.contracts.model.Contract;
+import gov.cms.ab2d.contracts.model.ContractDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ContractTest {
+    private final static String CONTRACT_NAME = "Name";
+    private final static String PARENT_NAME = "Parent";
+    private final static String MARKETING_NAME = "Marketing Name";
+    private final static String CONTRACT_NUMBER = "S12345";
+    private final static OffsetDateTime NOW = OffsetDateTime.now();
+    private final static Long ID = 1L;
+    private final static Long PARENT_ID = 2L;
+    private final static Integer MEDICARE_ELIGIBLE = 95;
+    private final static Integer TOTAL_ENROLLMENT = 100;
+
+    private Contract contract;
+
+    @BeforeEach
+    void init() {
+        contract = new Contract();
+        contract.setContractName(CONTRACT_NAME);
+        contract.setContractType(Contract.ContractType.NORMAL);
+        contract.setContractNumber(CONTRACT_NUMBER);
+        contract.setAttestedOn(NOW);
+        contract.setId(ID);
+        contract.setHpmsParentOrg(PARENT_NAME);
+        contract.setHpmsParentOrgId(PARENT_ID);
+        contract.setMedicareEligible(MEDICARE_ELIGIBLE);
+        contract.setTotalEnrollment(TOTAL_ENROLLMENT);
+        contract.setHpmsOrgMarketingName(MARKETING_NAME);
+        contract.setCreated(NOW);
+        contract.setModified(NOW);
+        contract.setUpdateMode(Contract.UpdateMode.AUTOMATIC);
+    }
+
+    @Test
+    void testContract() {
+        assertTrue(contract.hasChanges(MARKETING_NAME, PARENT_ID, PARENT_NAME, MARKETING_NAME,
+                TOTAL_ENROLLMENT, MEDICARE_ELIGIBLE));
+        assertTrue(contract.hasChanges(MARKETING_NAME, PARENT_ID, PARENT_NAME, MARKETING_NAME,
+                TOTAL_ENROLLMENT, MEDICARE_ELIGIBLE - 1));
+        assertTrue(contract.hasChanges(MARKETING_NAME, PARENT_ID, PARENT_NAME, MARKETING_NAME,
+                TOTAL_ENROLLMENT - 1, MEDICARE_ELIGIBLE));
+        assertTrue(contract.hasChanges(MARKETING_NAME, PARENT_ID, PARENT_NAME, MARKETING_NAME,
+                null, null));
+    }
+
+
+    @Test
+    void testOther() {
+        ContractDTO contractDTO = contract.toDTO();
+        assertEquals(contractDTO.getContractName(), CONTRACT_NAME);
+        assertEquals(contractDTO.getContractNumber(), CONTRACT_NUMBER);
+        assertEquals(contractDTO.getContractType(), Contract.ContractType.NORMAL);
+        assertEquals(contractDTO.getId(), contract.getId());
+        assertEquals(contractDTO.getAttestedOn(), contract.getAttestedOn());
+        assertEquals(contractDTO.getTotalEnrollment(), contract.getTotalEnrollment());
+        assertEquals(contractDTO.getMedicareEligible(), contract.getMedicareEligible());
+    }
+
+    @Test
+    void testType() {
+        assertFalse(contract.isTestContract());
+        contract.setContractType(Contract.ContractType.CLASSIC_TEST);
+        assertTrue(contract.isTestContract());
+        contract.setContractType(Contract.ContractType.SYNTHEA);
+        assertTrue(contract.isTestContract());
+
+        assertTrue(contract.isAutoUpdatable());
+        contract.setUpdateMode(Contract.UpdateMode.MANUAL);
+        assertFalse(contract.isAutoUpdatable());
+        contract.setUpdateMode(Contract.UpdateMode.NONE);
+        assertFalse(contract.isAutoUpdatable());
+    }
+
+    @Test
+    void testTime() {
+        ZonedDateTime zonedDateTime = contract.getESTAttestationTime();
+        assertEquals(0, zonedDateTime.toOffsetDateTime().toInstant().compareTo(NOW.toInstant()));
+        System.out.println("Zoned  DateTime: " + zonedDateTime);
+        System.out.println("Passed DateTime: " + NOW);
+    }
+
+    @Test
+    void testAttestation() {
+        assertTrue(contract.hasAttestation());
+        contract.clearAttestation();
+        assertFalse(contract.hasAttestation());
+    }
+
+    @Test
+    void testUpdate() {
+        contract.updateOrg(CONTRACT_NAME + "1",
+                PARENT_ID + 1, PARENT_NAME + "1",
+                MARKETING_NAME + "1", TOTAL_ENROLLMENT + 1,
+                MEDICARE_ELIGIBLE + 1);
+
+        assertEquals(contract.getContractName(),CONTRACT_NAME + "1");
+        assertEquals(contract.getHpmsParentOrgId(),PARENT_ID + 1);
+        assertEquals(contract.getHpmsParentOrg(),PARENT_NAME + "1");
+        assertEquals(contract.getTotalEnrollment(),TOTAL_ENROLLMENT + 1);
+        assertEquals(contract.getMedicareEligible(),MEDICARE_ELIGIBLE + 1);
+        assertEquals(contract.getAttestedOn(), NOW);
+        assertEquals(contract.getContractType(), Contract.ContractType.NORMAL);
+        assertEquals(0, contract.getESTAttestationTime().toOffsetDateTime().toInstant().compareTo(NOW.toInstant()));
+        assertEquals(contract.getId(), ID);
+    }
+
+    @Test
+    void testConst() {
+        Contract newContract = new Contract(CONTRACT_NUMBER, CONTRACT_NAME, PARENT_ID, PARENT_NAME,
+                MARKETING_NAME, TOTAL_ENROLLMENT, MEDICARE_ELIGIBLE);
+        assertEquals(newContract.getContractNumber(), contract.getContractNumber());
+        assertEquals(newContract.getContractName(), contract.getContractName());
+        assertEquals(newContract.getHpmsParentOrg(), contract.getHpmsParentOrg());
+        assertEquals(newContract.getHpmsParentOrgId(), contract.getHpmsParentOrgId());
+        assertEquals(newContract.getTotalEnrollment(), contract.getTotalEnrollment());
+        assertEquals(newContract.getMedicareEligible(), contract.getMedicareEligible());
+        assertNotEquals(newContract.getESTAttestationTime(), contract.getESTAttestationTime());
+    }
+}

--- a/ab2d-events-client/src/test/java/gov/cms/ab2d/eventclient/config/SendSqsEventTest.java
+++ b/ab2d-events-client/src/test/java/gov/cms/ab2d/eventclient/config/SendSqsEventTest.java
@@ -51,7 +51,6 @@ public class SendSqsEventTest {
 
     private final ObjectMapper mapper = SQSConfig.objectMapper();
 
-
     @Test
     void testQueueUrl() {
         String url = amazonSQS.getQueueUrl(LOCAL_EVENTS_SQS).getQueueUrl();
@@ -83,7 +82,6 @@ public class SendSqsEventTest {
         List<Message> message1 = amazonSQS.receiveMessage(amazonSQS.getQueueUrl(LOCAL_EVENTS_SQS).getQueueUrl()).getMessages();
         List<Message> message2 = amazonSQS.receiveMessage(amazonSQS.getQueueUrl(LOCAL_EVENTS_SQS).getQueueUrl()).getMessages();
 
-
         assertTrue(message1.get(0).getBody().contains(mapper.writeValueAsString(sentApiRequestEvent)));
         assertTrue(message2.get(0).getBody().contains(mapper.writeValueAsString(sentApiResponseEvent)));
     }
@@ -105,7 +103,6 @@ public class SendSqsEventTest {
 
         List<Message> message1 = amazonSQS.receiveMessage(amazonSQS.getQueueUrl("ab2d-dev-events-sqs").getQueueUrl()).getMessages();
         List<Message> message2 = amazonSQS.receiveMessage(amazonSQS.getQueueUrl("ab2d-dev-events-sqs").getQueueUrl()).getMessages();
-
 
         assertTrue(message1.get(0).getBody().contains(mapper.writeValueAsString(sentApiRequestEvent)));
         assertTrue(message2.get(0).getBody().contains(mapper.writeValueAsString(sentApiResponseEvent)));

--- a/ab2d-properties-client/src/test/java/gov/cms/ab2d/properties/client/PropertiesClientTest.java
+++ b/ab2d-properties-client/src/test/java/gov/cms/ab2d/properties/client/PropertiesClientTest.java
@@ -1,0 +1,34 @@
+package gov.cms.ab2d.properties.client;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class PropertiesClientTest {
+    @Test
+    void testGettingProperties() {
+        final String testKey = "one";
+        PropertiesClient client = new PropertiesClientImpl();
+        System.out.println(client.getAllProperties());
+        Property property = client.getProperty("coverage.update.queueing");
+        assertEquals("coverage.update.queueing", property.getKey());
+        assertEquals("engaged", property.getValue());
+        Property oneProp = client.setProperty(testKey, "two");
+        assertNotNull(oneProp);
+        assertEquals(testKey, oneProp.getKey());
+        assertEquals("two", oneProp.getValue());
+        Property onePropLoad = client.getProperty(testKey);
+        assertEquals(testKey, onePropLoad.getKey());
+        assertEquals("two", onePropLoad.getValue());
+        Property onePropUpdate = client.setProperty(testKey, "three");
+        assertEquals(testKey, onePropUpdate.getKey());
+        assertEquals("three", onePropUpdate.getValue());
+        Property onePropUpdateLoad = client.getProperty(testKey);
+        assertEquals(testKey, onePropUpdateLoad.getKey());
+        assertEquals("three", onePropUpdateLoad.getValue());
+        client.deleteProperty(testKey);
+        assertThrows(PropertyNotFoundException.class, () -> client.getProperty(testKey));
+    }
+}

--- a/ab2d-properties-client/src/test/java/gov/cms/ab2d/properties/client/PropertiesClientTest.java
+++ b/ab2d-properties-client/src/test/java/gov/cms/ab2d/properties/client/PropertiesClientTest.java
@@ -13,7 +13,6 @@ public class PropertiesClientTest {
     void testGettingProperties() {
         final String testKey = "one";
         PropertiesClient client = new PropertiesClientImpl();
-        // System.out.println(client.getAllProperties());
         Property property = client.getProperty("coverage.update.queueing");
         assertEquals("coverage.update.queueing", property.getKey());
         assertEquals("engaged", property.getValue());

--- a/ab2d-properties-client/src/test/java/gov/cms/ab2d/properties/client/PropertiesClientTest.java
+++ b/ab2d-properties-client/src/test/java/gov/cms/ab2d/properties/client/PropertiesClientTest.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.properties.client;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -7,11 +8,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PropertiesClientTest {
+    @Disabled
     @Test
     void testGettingProperties() {
         final String testKey = "one";
         PropertiesClient client = new PropertiesClientImpl();
-        System.out.println(client.getAllProperties());
+        // System.out.println(client.getAllProperties());
         Property property = client.getProperty("coverage.update.queueing");
         assertEquals("coverage.update.queueing", property.getKey());
         assertEquals("engaged", property.getValue());


### PR DESCRIPTION
**JIRA Tickets:**

[AB2D-5349](https://jira.cms.gov/browse/AB2D-5349) - Provide mechanism for passing coverage data back to contract service users

### What Does This PR Do?

HPMS provides total enrollment and medicare eligible numbers for contracts. The contract service will now provide that information. The values provided will be the last known values, assuming they are not more than 60 days old

### What Should Reviewers Watch For?

### Usage/Deployment Instructions

The database components require the new version of the contract service to run since they add two columns used by this client. The contract service should be deployed before this version of the library is used.

### Impacted External Components

### Database Changes

The contract service creates two columns to the database that is defined here.

### Limitations

### Security Implications
<!-- If any boxes are checked, a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence -->

- [ ] This PR adds new software dependencies
- [ ] This PR modifies or invalidates our security controls
- [ ] This PR stores or transmits data that was not stored or transmitted before

<!-- If any boxes are checked, please add @StewGoin as a reviewer, and this PR should not be merged unless/until he also approves it. -->

- [ ] This PR requires additional review of its security implications for other reasons

### What Needs to Be Merged and Deployed Before this PR?

### Submitter Checklist

- [ ] This PR includes any required documentation changes, (`README`, changelog / release notes, website).
- [ ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments.
- [ ] Code checked for PHI/PII exposure