### PR TITLE
AB2D-5482 Sprint 4: Perform Dependabot Updates by the end of each sprint

### DIFF
--- a/ab2d-sns-client/build.gradle
+++ b/ab2d-sns-client/build.gradle
@@ -3,8 +3,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter:2.7.8'
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
-    implementation 'com.amazonaws:aws-java-sdk-sns:1.12.464'
-    implementation 'software.amazon.awssdk:sns:2.20.61'
+    implementation 'com.amazonaws:aws-java-sdk-sns:1.12.477'
+    implementation 'software.amazon.awssdk:sns:2.20.74'
     implementation(project(":ab2d-events-client"))
 
     testCompileOnly "org.projectlombok:lombok:${lombokVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
     id 'java-library'
-    id 'com.jfrog.artifactory' version '4.31.9' apply false
-    id "org.sonarqube" version "4.0.0.2929"
+    id 'com.jfrog.artifactory' version '4.32.0' apply false
+    id "org.sonarqube" version "4.1.0.3113"
     id 'org.cyclonedx.bom' version '1.7.4'
 }
 
@@ -36,15 +36,15 @@ ext {
     resolverRepo = 'ab2d-main'
 
     commonsLangVersion='3.12.0'
-    lombokVersion = '1.18.26'
+    lombokVersion = '1.18.28'
     hapiVersion = '6.4.4'
     springBootVersion='2.7.6'
     springCloudVersion='2021.0.3'
     newRelicVersion='8.2.0'
-    testContainerVersion='1.18.0'
+    testContainerVersion='1.18.1'
     mockServerVersion='5.15.0'
-    liquibaseVersion="4.21.1"
-    jacksonVersion = "2.15.0"
+    liquibaseVersion="4.22.0"
+    jacksonVersion = "2.15.1"
     slackAPIVersion='1.29.2'
     jupiterVersion='5.9.3'
     hl7Version = '5.6.971'


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-5482

## 🛠 Changes

Bump:
[testContainerVersion](https://github.com/CMSgov/AB2D-Libs/pull/308)
[liquibase-core](https://github.com/CMSgov/AB2D-Libs/pull/312)
[jacksonVersion](https://github.com/CMSgov/AB2D-Libs/pull/315)
[artifactory](https://github.com/CMSgov/AB2D-Libs/pull/317)
[hapiVersion](https://github.com/CMSgov/AB2D-Libs/pull/319)
[sonarqube](https://github.com/CMSgov/AB2D-Libs/pull/321)
[lombok](https://github.com/CMSgov/AB2D-Libs/pull/322)
[aws](https://github.com/CMSgov/AB2D-Libs/pull/323)
[awssdk](https://github.com/CMSgov/AB2D-Libs/pull/324)


## ℹ️ Context for reviewers

This PR addresses dependabot PR's for Sprint 4

## 🔒 Security Implications

- [x] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
