### PR TITLE
PLT-283 Pass artifactory creds to sbom command

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,9 @@ pipeline {
 
         stage("Generate SBOM") {
             steps {
-                sh 'gradle cyclonedxBom'
+                withCredentials([usernamePassword(credentialsId: 'artifactoryuserpass', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_PASSWORD')]) {
+                    sh 'gradle cyclonedxBom'
+                }
             }
         }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-283

## 🛠 Changes

Wrap the "gradle cyclonedxBom" command in withCredentials to pass Artifactory username and password. Not clear why this is needed now but it works.

## ℹ️ Context for reviewers

Corrects failure in SBOM stage in builds of AB2D-Libs.

## ✅ Acceptance Validation

Tested in replay of AB2D-Libs build.

## 🔒 Security Implications

None.
