### PR TITLE
[AB2D-5916]-add aws-autoconfigure dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,14 +22,14 @@ ext {
             : System.getenv()['ARTIFACTORY_PASSWORD']
 
     // AB2D libraries
-    fhirVersion='1.2.0'
-    bfdVersion='2.1.0'
-    aggregatorVersion='1.3.0'
-    filtersVersion='1.9.0'
-    eventClientVersion='1.12.0'
-    propertiesClientVersion='1.2.0'
-    contractClientVersion='1.2.0'
-    snsClientVersion='0.2.0'
+    fhirVersion='1.2.1'
+    bfdVersion='2.1.1'
+    aggregatorVersion='1.3.1'
+    filtersVersion='1.9.1'
+    eventClientVersion='1.12.1'
+    propertiesClientVersion='1.2.1'
+    contractClientVersion='1.2.1'
+    snsClientVersion='0.2.1'
 
     sourcesRepo = 'ab2d-maven-repo'
     deployerRepo = 'ab2d-main'
@@ -143,6 +143,7 @@ subprojects {
         implementation(platform("org.springframework.boot:spring-boot-dependencies:$springBootVersion"))
         implementation(platform("io.awspring.cloud:spring-cloud-aws-dependencies:$springCloudAwsVersion"))
         implementation(platform("io.awspring.cloud:spring-cloud-aws-core:${springCloudAwsVersion}"))
+        implementation(platform("io.awspring.cloud:spring-cloud-aws-autoconfigure:${springCloudAwsVersion}"))
         implementation(platform("org.liquibase:liquibase-core:$liquibaseVersion"))
         implementation(platform("com.newrelic.agent.java:newrelic-api:$newRelicVersion"))
         implementation(platform("org.testcontainers:testcontainers:$testContainerVersion"))


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-5916

## 🛠 Changes

Adds dependency on io.awspring autoconfigure
Updates library versions.

## ℹ️ Context for reviewers

Folllowup to earlier upgrade. Missed a dependency that is required for ab2d-common to build.

## ✅ Acceptance Validation

(How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable.)

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
