### PR TITLE
[AB2D-5957] Update ab2d-events-client autoconfigure

### DIFF
--- a/ab2d-events-client/src/test/java/gov/cms/ab2d/eventclient/SpringBootApp.java
+++ b/ab2d-events-client/src/test/java/gov/cms/ab2d/eventclient/SpringBootApp.java
@@ -10,7 +10,9 @@ import org.springframework.context.annotation.Bean;
         exclude = {
                 io.awspring.cloud.autoconfigure.context.ContextInstanceDataAutoConfiguration.class,
                 io.awspring.cloud.autoconfigure.context.ContextStackAutoConfiguration.class,
-                io.awspring.cloud.autoconfigure.context.ContextRegionProviderAutoConfiguration.class
+                io.awspring.cloud.autoconfigure.context.ContextRegionProviderAutoConfiguration.class,
+                io.awspring.cloud.autoconfigure.messaging.SqsAutoConfiguration.class
+
         }
 )
 public class SpringBootApp {

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ ext {
     bfdVersion='2.1.1'
     aggregatorVersion='1.3.1'
     filtersVersion='1.9.1'
-    eventClientVersion='1.12.1'
+    eventClientVersion='1.12.2'
     propertiesClientVersion='1.2.1'
     contractClientVersion='1.2.1'
     snsClientVersion='0.2.1'


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-5957

## 🛠 Changes

updated autoconfiguration for ab2d-events-client
updated ab2d-events-client to version 1.12.2

## ℹ️ Context for reviewers

updated autoconfiguration to exclude SqsAutoconfiguration.class.
This is apparently needed for ab2d-events tests to run properly.

## ✅ Acceptance Validation

AB2D-Libs was built locally:

<img width="281" alt="Screenshot 2024-02-07 at 12 37 40 PM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/edaf8230-6e56-42df-951e-0f68e522fe36">


## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
