### PR TITLE
[WIP] [AB2D-5907, 6040] AB2D Libs Code Smells - Copy of 372

### DIFF
--- a/ab2d-bfd/src/main/java/gov/cms/ab2d/bfd/client/BFDClientImpl.java
+++ b/ab2d-bfd/src/main/java/gov/cms/ab2d/bfd/client/BFDClientImpl.java
@@ -41,8 +41,8 @@ public class BFDClientImpl implements BFDClient {
     private final BFDSearch bfdSearch;
     private final BfdClientVersions bfdClientVersions;
 
-    private final String includeIdentifiersHeader = "IncludeIdentifiers";
-    private final String mbiHeaderValue = "mbi";
+    private static final String INCLUDE_IDENTIFIERS_HEADER = "IncludeIdentifiers";
+    private static final String MBI_HEADER_VALUE = "mbi";
 
     public BFDClientImpl(BFDSearch bfdSearch, BfdClientVersions bfdClientVersions) {
         this.bfdSearch = bfdSearch;
@@ -128,7 +128,7 @@ public class BFDClientImpl implements BFDClient {
                 .next(bundle)
                 .withAdditionalHeader(BFDClient.BFD_HDR_BULK_CLIENTID, contractNum)
                 .withAdditionalHeader(BFDClient.BFD_HDR_BULK_JOBID, getJobId())
-                .withAdditionalHeader(includeIdentifiersHeader, mbiHeaderValue)
+                .withAdditionalHeader(INCLUDE_IDENTIFIERS_HEADER, MBI_HEADER_VALUE)
                 .encodedJson()
                 .execute();
     }
@@ -160,7 +160,7 @@ public class BFDClientImpl implements BFDClient {
                 .where(monthCriterion)
                 .withAdditionalHeader(BFDClient.BFD_HDR_BULK_CLIENTID, contractNumber)
                 .withAdditionalHeader(BFDClient.BFD_HDR_BULK_JOBID, getJobId())
-                .withAdditionalHeader(includeIdentifiersHeader, mbiHeaderValue)
+                .withAdditionalHeader(INCLUDE_IDENTIFIERS_HEADER, MBI_HEADER_VALUE)
                 .count(contractToBenePageSize)
                 .returnBundle(version.getBundleClass())
                 .encodedJson()
@@ -188,7 +188,7 @@ public class BFDClientImpl implements BFDClient {
                 .and(yearCriterion)
                 .withAdditionalHeader(BFDClient.BFD_HDR_BULK_CLIENTID, contractNumber)
                 .withAdditionalHeader(BFDClient.BFD_HDR_BULK_JOBID, getJobId())
-                .withAdditionalHeader(includeIdentifiersHeader, mbiHeaderValue)
+                .withAdditionalHeader(INCLUDE_IDENTIFIERS_HEADER, MBI_HEADER_VALUE)
                 .count(contractToBenePageSize)
                 .returnBundle(version.getBundleClass())
                 .encodedJson()

--- a/ab2d-bfd/src/main/java/gov/cms/ab2d/bfd/client/BFDClientImpl.java
+++ b/ab2d-bfd/src/main/java/gov/cms/ab2d/bfd/client/BFDClientImpl.java
@@ -41,6 +41,9 @@ public class BFDClientImpl implements BFDClient {
     private final BFDSearch bfdSearch;
     private final BfdClientVersions bfdClientVersions;
 
+    private final String includeIdentifiersHeader = "IncludeIdentifiers";
+    private final String mbiHeaderValue = "mbi";
+
     public BFDClientImpl(BFDSearch bfdSearch, BfdClientVersions bfdClientVersions) {
         this.bfdSearch = bfdSearch;
         this.bfdClientVersions = bfdClientVersions;
@@ -125,7 +128,7 @@ public class BFDClientImpl implements BFDClient {
                 .next(bundle)
                 .withAdditionalHeader(BFDClient.BFD_HDR_BULK_CLIENTID, contractNum)
                 .withAdditionalHeader(BFDClient.BFD_HDR_BULK_JOBID, getJobId())
-                .withAdditionalHeader("IncludeIdentifiers", "mbi")
+                .withAdditionalHeader(includeIdentifiersHeader, mbiHeaderValue)
                 .encodedJson()
                 .execute();
     }
@@ -157,7 +160,7 @@ public class BFDClientImpl implements BFDClient {
                 .where(monthCriterion)
                 .withAdditionalHeader(BFDClient.BFD_HDR_BULK_CLIENTID, contractNumber)
                 .withAdditionalHeader(BFDClient.BFD_HDR_BULK_JOBID, getJobId())
-                .withAdditionalHeader("IncludeIdentifiers", "mbi")
+                .withAdditionalHeader(includeIdentifiersHeader, mbiHeaderValue)
                 .count(contractToBenePageSize)
                 .returnBundle(version.getBundleClass())
                 .encodedJson()
@@ -185,7 +188,7 @@ public class BFDClientImpl implements BFDClient {
                 .and(yearCriterion)
                 .withAdditionalHeader(BFDClient.BFD_HDR_BULK_CLIENTID, contractNumber)
                 .withAdditionalHeader(BFDClient.BFD_HDR_BULK_JOBID, getJobId())
-                .withAdditionalHeader("IncludeIdentifiers", "mbi")
+                .withAdditionalHeader(includeIdentifiersHeader, mbiHeaderValue)
                 .count(contractToBenePageSize)
                 .returnBundle(version.getBundleClass())
                 .encodedJson()

--- a/ab2d-bfd/src/test/java/gov/cms/ab2d/bfd/client/BlueButtonClientR4Test.java
+++ b/ab2d-bfd/src/test/java/gov/cms/ab2d/bfd/client/BlueButtonClientR4Test.java
@@ -110,8 +110,8 @@ public class BlueButtonClientR4Test {
         org.hl7.fhir.r4.model.Bundle response = (org.hl7.fhir.r4.model.Bundle) bbc.requestEOBFromServer(R4, TEST_PATIENT_ID, CONTRACT);
 
         response.getEntry().forEach((entry) -> assertEquals(
-                entry.getResource().getResourceType(),
                 org.hl7.fhir.r4.model.ResourceType.ExplanationOfBenefit,
+                entry.getResource().getResourceType(),
                 "EOB bundles returned by the BlueButton client should only contain EOB objects"
         ));
     }

--- a/ab2d-bfd/src/test/java/gov/cms/ab2d/bfd/client/BlueButtonClientSTU3Test.java
+++ b/ab2d-bfd/src/test/java/gov/cms/ab2d/bfd/client/BlueButtonClientSTU3Test.java
@@ -255,8 +255,8 @@ public class BlueButtonClientSTU3Test {
         org.hl7.fhir.dstu3.model.Bundle response = (org.hl7.fhir.dstu3.model.Bundle) bbc.requestEOBFromServer(STU3, TEST_PATIENT_ID, CONTRACT);
 
         response.getEntry().forEach((entry) -> assertEquals(
-                entry.getResource().getResourceType(),
                 org.hl7.fhir.dstu3.model.ResourceType.ExplanationOfBenefit,
+                entry.getResource().getResourceType(),
                 "EOB bundles returned by the BlueButton client should only contain EOB objects"
         ));
     }

--- a/ab2d-contracts-client/src/test/java/gov/cms/ab2d/contracts/utils/ContractTest.java
+++ b/ab2d-contracts-client/src/test/java/gov/cms/ab2d/contracts/utils/ContractTest.java
@@ -60,9 +60,9 @@ public class ContractTest {
     @Test
     void testOther() {
         ContractDTO contractDTO = contract.toDTO();
-        assertEquals(contractDTO.getContractName(), CONTRACT_NAME);
-        assertEquals(contractDTO.getContractNumber(), CONTRACT_NUMBER);
-        assertEquals(contractDTO.getContractType(), Contract.ContractType.NORMAL);
+        assertEquals(CONTRACT_NAME, contractDTO.getContractName());
+        assertEquals(CONTRACT_NUMBER, contractDTO.getContractNumber());
+        assertEquals(Contract.ContractType.NORMAL, contractDTO.getContractType());
         assertEquals(contractDTO.getId(), contract.getId());
         assertEquals(contractDTO.getAttestedOn(), contract.getAttestedOn());
         assertEquals(contractDTO.getTotalEnrollment(), contract.getTotalEnrollment());
@@ -106,15 +106,15 @@ public class ContractTest {
                 MARKETING_NAME + "1", TOTAL_ENROLLMENT + 1,
                 MEDICARE_ELIGIBLE + 1);
 
-        assertEquals(contract.getContractName(), CONTRACT_NAME + "1");
-        assertEquals(contract.getHpmsParentOrgId(), PARENT_ID + 1);
-        assertEquals(contract.getHpmsParentOrg(), PARENT_NAME + "1");
-        assertEquals(contract.getTotalEnrollment(), TOTAL_ENROLLMENT + 1);
-        assertEquals(contract.getMedicareEligible(), MEDICARE_ELIGIBLE + 1);
-        assertEquals(contract.getAttestedOn(), NOW);
-        assertEquals(contract.getContractType(), Contract.ContractType.NORMAL);
+        assertEquals(CONTRACT_NAME + "1", contract.getContractName());
+        assertEquals(PARENT_ID + 1, contract.getHpmsParentOrgId());
+        assertEquals(PARENT_NAME + "1", contract.getHpmsParentOrg());
+        assertEquals(TOTAL_ENROLLMENT + 1, contract.getTotalEnrollment());
+        assertEquals(MEDICARE_ELIGIBLE + 1, contract.getMedicareEligible());
+        assertEquals(NOW, contract.getAttestedOn());
+        assertEquals(Contract.ContractType.NORMAL, contract.getContractType());
         assertEquals(0, contract.getESTAttestationTime().toOffsetDateTime().toInstant().compareTo(NOW.toInstant()));
-        assertEquals(contract.getId(), ID);
+        assertEquals(ID, contract.getId());
     }
 
     @Test

--- a/ab2d-events-client/src/main/java/gov/cms/ab2d/eventclient/events/JobStatusChangeEvent.java
+++ b/ab2d-events-client/src/main/java/gov/cms/ab2d/eventclient/events/JobStatusChangeEvent.java
@@ -31,7 +31,6 @@ public class JobStatusChangeEvent extends LoggableEvent {
 
         // Prettify alert
         String label = "";
-        String description = this.description;
         if (description != null && !description.isBlank()) {
             String[] labelAndDescription = description.split("\\s+", 2);
 

--- a/ab2d-events-client/src/main/java/gov/cms/ab2d/eventclient/events/JobSummaryEvent.java
+++ b/ab2d-events-client/src/main/java/gov/cms/ab2d/eventclient/events/JobSummaryEvent.java
@@ -27,8 +27,8 @@ public class JobSummaryEvent extends LoggableEvent {
     public JobSummaryEvent() {
         // Adding a nested comment here to satisfy sonarqube code smells.
         // This method is intentionally blank for the following reason:
-        
-        // This is a constructor for a subtype of LoggableEvent. 
+
+        // This is a constructor for a subtype of LoggableEvent.
         // We construct this type while overriding asMessage to differentiate functionality.
     }
 

--- a/ab2d-events-client/src/main/java/gov/cms/ab2d/eventclient/events/JobSummaryEvent.java
+++ b/ab2d-events-client/src/main/java/gov/cms/ab2d/eventclient/events/JobSummaryEvent.java
@@ -26,9 +26,9 @@ public class JobSummaryEvent extends LoggableEvent {
 
     public JobSummaryEvent() {
         // Adding a nested comment here to satisfy sonarqube code smells.
-        // This method is an intentionally blank for the following reason:
+        // This method is intentionally blank for the following reason:
         
-        // This is a constructor for a subtype of loggableEvent. 
+        // This is a constructor for a subtype of LoggableEvent. 
         // We construct this type while overriding asMessage to differentiate functionality.
     }
 

--- a/ab2d-events-client/src/main/java/gov/cms/ab2d/eventclient/events/JobSummaryEvent.java
+++ b/ab2d-events-client/src/main/java/gov/cms/ab2d/eventclient/events/JobSummaryEvent.java
@@ -24,7 +24,13 @@ public class JobSummaryEvent extends LoggableEvent {
     private int numOptedOut;
     private int errorSearched;
 
-    public JobSummaryEvent() { }
+    public JobSummaryEvent() {
+        // Adding a nested comment here to satisfy sonarqube code smells.
+        // This method is an intentionally blank for the following reason:
+        
+        // This is a constructor for a subtype of loggableEvent. 
+        // We construct this type while overriding asMessage to differentiate functionality.
+    }
 
     @Override
     public String asMessage() {

--- a/ab2d-events-client/src/main/java/gov/cms/ab2d/eventclient/events/LoggableEvent.java
+++ b/ab2d-events-client/src/main/java/gov/cms/ab2d/eventclient/events/LoggableEvent.java
@@ -63,17 +63,11 @@ public abstract class LoggableEvent {
      */
     public int hashCode() {
         int result = 1;
-        String environment = this.getEnvironment();
         result = result * 59 + (environment == null ? 43 : environment.hashCode());
-        Long id = this.getId();
         result = result * 59 + (id == null ? 43 : id.hashCode());
-        String awsId = this.getAwsId();
         result = result * 59 + (awsId == null ? 43 : awsId.hashCode());
-        OffsetDateTime timeOfEvent = this.getTimeOfEvent();
         result = result * 59 + (timeOfEvent == null ? 43 : timeOfEvent.hashCode());
-        String user = this.getOrganization();
-        result = result * 59 + (user == null ? 43 : user.hashCode());
-        String jobId = this.getJobId();
+        result = result * 59 + (organization == null ? 43 : organization.hashCode());
         result = result * 59 + (jobId == null ? 43 : jobId.hashCode());
         return result;
     }

--- a/ab2d-events-client/src/main/java/gov/cms/ab2d/eventclient/events/LoggableEvent.java
+++ b/ab2d-events-client/src/main/java/gov/cms/ab2d/eventclient/events/LoggableEvent.java
@@ -9,7 +9,7 @@ import lombok.Data;
  */
 @Data
 public abstract class LoggableEvent {
-    public LoggableEvent() { }
+    protected LoggableEvent() { }
 
     // If it's dev, prod, etc.
     private String environment;
@@ -37,7 +37,7 @@ public abstract class LoggableEvent {
      * @param jobId uuid of job
      * @throws IllegalArgumentException if the organization may be an okta client credential
      */
-    public LoggableEvent(OffsetDateTime timeOfEvent, String organization, String jobId) {
+    protected LoggableEvent(OffsetDateTime timeOfEvent, String organization, String jobId) {
         this.timeOfEvent = timeOfEvent;
         this.organization = organization;
         this.jobId = jobId;

--- a/ab2d-events-client/src/main/java/gov/cms/ab2d/eventclient/messages/SQSMessages.java
+++ b/ab2d-events-client/src/main/java/gov/cms/ab2d/eventclient/messages/SQSMessages.java
@@ -6,5 +6,5 @@ import lombok.extern.slf4j.Slf4j;
 @Data
 @Slf4j
 public abstract class SQSMessages {
-    public SQSMessages() { }
+    protected SQSMessages() { }
 }

--- a/ab2d-events-client/src/test/java/gov/cms/ab2d/eventclient/config/SendSqsEventTest.java
+++ b/ab2d-events-client/src/test/java/gov/cms/ab2d/eventclient/config/SendSqsEventTest.java
@@ -169,9 +169,9 @@ public class SendSqsEventTest {
     @Test
     void testAB2DEEnvironment() {
         new SQSConfig("", "", Ab2dEnvironment.DEV);
-        assertEquals(System.getProperty("sqs.queue-name"), "ab2d-dev-events-sqs");
+        assertEquals("ab2d-dev-events-sqs", System.getProperty("sqs.queue-name"));
 
         new SQSConfig("", "", Ab2dEnvironment.SANDBOX);
-        assertEquals(System.getProperty("sqs.queue-name"), "ab2d-sbx-sandbox-events-sqs");
+        assertEquals("ab2d-sbx-sandbox-events-sqs", System.getProperty("sqs.queue-name"));
     }
 }

--- a/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/BundleUtils.java
+++ b/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/BundleUtils.java
@@ -20,6 +20,10 @@ public final class BundleUtils {
     public static final String EOB = "ExplanationOfBenefit";
     public static final String PATIENT = "Patient";
 
+    private static final String GET_LINK_METHOD_NAME = "getLink";
+    private static final String GET_RELATION_METHOD_NAME = "getRelation";
+    private static final String GET_RESOURCE_METHOD_NAME = "getResource";
+
     private BundleUtils() { }
 
     /**
@@ -32,10 +36,10 @@ public final class BundleUtils {
         if (bundle == null) {
             return null;
         }
-        List<?> links = (List<?>) Versions.invokeGetMethod(bundle, "getLink");
+        List<?> links = (List<?>) Versions.invokeGetMethod(bundle, GET_LINK_METHOD_NAME);
         List<String> listValues = new ArrayList<>();
         for (Object o : links) {
-            listValues.add((String) Versions.invokeGetMethod(o, "getRelation"));
+            listValues.add((String) Versions.invokeGetMethod(o, GET_RELATION_METHOD_NAME));
         }
         return String.join(" , ", listValues);
     }
@@ -50,10 +54,10 @@ public final class BundleUtils {
         if (bundle == null) {
             return null;
         }
-        List<?> links = (List<?>) Versions.invokeGetMethod(bundle, "getLink");
+        List<?> links = (List<?>) Versions.invokeGetMethod(bundle, GET_LINK_METHOD_NAME);
         List<String> listValues = new ArrayList<>();
         for (Object o : links) {
-            listValues.add(Versions.invokeGetMethod(o, "getRelation") + " -> " +
+            listValues.add(Versions.invokeGetMethod(o, GET_RELATION_METHOD_NAME) + " -> " +
                     Versions.invokeGetMethod(o, "getUrl"));
         }
         return String.join(" , ", listValues);
@@ -70,7 +74,7 @@ public final class BundleUtils {
             return null;
         }
         try {
-            return (IBaseBackboneElement) Versions.invokeGetMethodWithArg(bundle, "getLink", LINK_NEXT, String.class);
+            return (IBaseBackboneElement) Versions.invokeGetMethodWithArg(bundle, GET_LINK_METHOD_NAME, LINK_NEXT, String.class);
         } catch (Exception ex) {
             return null;
         }
@@ -89,7 +93,7 @@ public final class BundleUtils {
         }
         List entries = getEntries(bundle);
         return entries.stream()
-                .map(c -> Versions.invokeGetMethod(c, "getResource"))
+                .map(c -> Versions.invokeGetMethod(c, GET_RESOURCE_METHOD_NAME))
                 .filter(c -> Versions.invokeGetMethod(c, "getResourceType") == version.getPatientEnum());
     }
 
@@ -116,7 +120,7 @@ public final class BundleUtils {
     public static List<IBaseResource> getEobResources(List<IBaseBackboneElement> bundleComponents) {
         try {
             return bundleComponents.stream()
-                    .map(c -> (IBaseResource) Versions.invokeGetMethod(c, "getResource"))
+                    .map(c -> (IBaseResource) Versions.invokeGetMethod(c, GET_RESOURCE_METHOD_NAME))
                     .filter(Objects::nonNull)
                     .filter(BundleUtils::isExplanationOfBenefitResource)
                     .collect(Collectors.toList());

--- a/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/ExtensionUtils.java
+++ b/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/ExtensionUtils.java
@@ -23,6 +23,8 @@ public final class ExtensionUtils {
     public static final String ID_EXT = "http://hl7.org/fhir/StructureDefinition/elementdefinition-identifier";
     public static final String REF_YEAR_EXT = "https://bluebutton.cms.gov/resources/variables/rfrnc_yr";
 
+    private static final String EXTENSION_CLASSNAME = "Extension";
+
     private ExtensionUtils() { }
 
     /**
@@ -37,7 +39,7 @@ public final class ExtensionUtils {
             return;
         }
         try {
-            Versions.invokeSetMethod(resource, "addExtension", extension, Class.forName(version.getClassName("Extension")));
+            Versions.invokeSetMethod(resource, "addExtension", extension, Class.forName(version.getClassName(EXTENSION_CLASSNAME)));
         } catch (Exception ex) {
             log.error("Unable to add Extension");
         }
@@ -59,7 +61,7 @@ public final class ExtensionUtils {
         Object coding = Versions.getObject(version, "Coding");
         Versions.invokeSetMethod(coding, "setCode", current ? CURRENT_MBI : HISTORIC_MBI, String.class);
 
-        Object currencyExtension = Versions.getObject(version, "Extension");
+        Object currencyExtension = Versions.getObject(version, EXTENSION_CLASSNAME);
         Versions.invokeSetMethod(currencyExtension, "setUrl", CURRENCY_IDENTIFIER, String.class);
         try {
             Versions.invokeSetMethod(currencyExtension, "setValue", coding, Class.forName(version.getClassName("Type")));
@@ -69,7 +71,7 @@ public final class ExtensionUtils {
 
         Versions.invokeSetMethod(identifier, "setExtension", List.of(currencyExtension), List.class);
 
-        Object ext = Versions.getObject(version, "Extension");
+        Object ext = Versions.getObject(version, EXTENSION_CLASSNAME);
         Versions.invokeSetMethod(ext, "setUrl", ID_EXT, String.class);
         try {
             Versions.invokeSetMethod(ext, "setValue", identifier, Class.forName(version.getClassName("Type")));

--- a/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/ExtensionUtils.java
+++ b/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/ExtensionUtils.java
@@ -24,6 +24,7 @@ public final class ExtensionUtils {
     public static final String REF_YEAR_EXT = "https://bluebutton.cms.gov/resources/variables/rfrnc_yr";
 
     private static final String EXTENSION_CLASSNAME = "Extension";
+    private static final String SET_VALUE_METHOD_NAME = "setValue";
 
     private ExtensionUtils() { }
 
@@ -56,7 +57,7 @@ public final class ExtensionUtils {
     public static IBase createMbiExtension(String mbi, boolean current, FhirVersion version) {
         Object identifier = Versions.getObject(version, "Identifier");
         Versions.invokeSetMethod(identifier, "setSystem", MBI_ID, String.class);
-        Versions.invokeSetMethod(identifier, "setValue", mbi, String.class);
+        Versions.invokeSetMethod(identifier, SET_VALUE_METHOD_NAME, mbi, String.class);
 
         Object coding = Versions.getObject(version, "Coding");
         Versions.invokeSetMethod(coding, "setCode", current ? CURRENT_MBI : HISTORIC_MBI, String.class);
@@ -64,7 +65,7 @@ public final class ExtensionUtils {
         Object currencyExtension = Versions.getObject(version, EXTENSION_CLASSNAME);
         Versions.invokeSetMethod(currencyExtension, "setUrl", CURRENCY_IDENTIFIER, String.class);
         try {
-            Versions.invokeSetMethod(currencyExtension, "setValue", coding, Class.forName(version.getClassName("Type")));
+            Versions.invokeSetMethod(currencyExtension, SET_VALUE_METHOD_NAME, coding, Class.forName(version.getClassName("Type")));
         } catch (Exception ex) {
             log.error("Unable to setValue");
         }
@@ -74,7 +75,7 @@ public final class ExtensionUtils {
         Object ext = Versions.getObject(version, EXTENSION_CLASSNAME);
         Versions.invokeSetMethod(ext, "setUrl", ID_EXT, String.class);
         try {
-            Versions.invokeSetMethod(ext, "setValue", identifier, Class.forName(version.getClassName("Type")));
+            Versions.invokeSetMethod(ext, SET_VALUE_METHOD_NAME, identifier, Class.forName(version.getClassName("Type")));
         } catch (Exception ex) {
             log.error("Unable to setValue");
         }

--- a/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/FhirVersion.java
+++ b/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/FhirVersion.java
@@ -148,15 +148,17 @@ public enum FhirVersion {
      * @return the OperationOutcome object
      */
     public IBaseResource getErrorOutcome(String msg) {
-        IBaseResource operationOutcome = (IBaseResource) Versions.getObject(this, "OperationOutcome");
+        String operationOutcomeClassName = "OperationOutcome";
+
+        IBaseResource operationOutcome = (IBaseResource) Versions.getObject(this, operationOutcomeClassName);
         List issues = (List) Versions.invokeGetMethod(operationOutcome, "getIssue");
 
-        Object newIssue = Versions.instantiateClass(this, "OperationOutcome", "OperationOutcomeIssueComponent");
+        Object newIssue = Versions.instantiateClass(this, operationOutcomeClassName, "OperationOutcomeIssueComponent");
 
-        Object severityError = Versions.instantiateEnum(this, "OperationOutcome", "IssueSeverity", "ERROR");
+        Object severityError = Versions.instantiateEnum(this, operationOutcomeClassName, "IssueSeverity", "ERROR");
         Versions.invokeSetMethod(newIssue, "setSeverity", severityError, severityError.getClass());
 
-        Object issueTypeInvalid = Versions.instantiateEnum(this, "OperationOutcome", "IssueType", "INVALID");
+        Object issueTypeInvalid = Versions.instantiateEnum(this, operationOutcomeClassName, "IssueType", "INVALID");
         Versions.invokeSetMethod(newIssue, "setCode", issueTypeInvalid, issueTypeInvalid.getClass());
         Object codableConcept = Versions.getObject(this, "CodeableConcept");
         Versions.invokeSetMethod(codableConcept, "setText", msg, String.class);

--- a/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/Versions.java
+++ b/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/Versions.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.fhir;
 
+import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 
 import java.lang.reflect.InvocationTargetException;
@@ -15,6 +16,7 @@ import java.util.*;
  *   5. The ability to determine which version is being used based on the URL passed from the HttpRequest
  */
 @Slf4j
+@UtilityClass
 public class Versions {
     /**
      * So we don't have to instantiate all Method objects, hold on to them so we can just invoke them when necessary

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/BundleUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/BundleUtilsTest.java
@@ -49,6 +49,9 @@ class BundleUtilsTest {
     void testErrors() {
         assertNull(BundleUtils.getEntries(null));
         assertEquals(0, BundleUtils.getTotal(null));
+        assertNull(BundleUtils.getEobResources(null));
+        assertNull(BundleUtils.getNextLink(null));
+
     }
 
     @Test

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/BundleUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/BundleUtilsTest.java
@@ -51,7 +51,7 @@ class BundleUtilsTest {
         assertEquals(0, BundleUtils.getTotal(null));
         assertNull(BundleUtils.getEobResources(null));
         assertNull(BundleUtils.getNextLink(null));
-
+        assertFalse(BundleUtils.isExplanationOfBenefitResource(null));
     }
 
     @Test

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/BundleUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/BundleUtilsTest.java
@@ -50,8 +50,15 @@ class BundleUtilsTest {
         assertNull(BundleUtils.getEntries(null));
         assertEquals(0, BundleUtils.getTotal(null));
         assertNull(BundleUtils.getEobResources(null));
+
         assertNull(BundleUtils.getNextLink(null));
         assertFalse(BundleUtils.isExplanationOfBenefitResource(null));
+
+        org.hl7.fhir.dstu3.model.Bundle bundle = new org.hl7.fhir.dstu3.model.Bundle();
+
+        assertNull(BundleUtils.getNextLink(bundle));
+        assertFalse(BundleUtils.isExplanationOfBenefitResource(bundle));
+
     }
 
     @Test

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
@@ -1,12 +1,10 @@
 package gov.cms.ab2d.fhir;
 
-import org.hl7.fhir.dstu3.model.Base;
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Coding;
 import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.dstu3.model.Patient;
-import org.hl7.fhir.dstu3.model.UriType;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.junit.jupiter.api.Test;
 
@@ -26,14 +24,6 @@ import static gov.cms.ab2d.fhir.IdentifierUtils.getIdentifiers;
 import static org.junit.jupiter.api.Assertions.*;
 
 class PatientIdentifierUtilsTest {
-    @Test
-    void dummy() {
-        Identifier id = new Identifier();
-        id.setSystem("systemVal");
-        Base[] val = id.getProperty(-887328209, "system", false);
-        String valS = ((UriType) val[0]).getValue();
-    }
-
     @Test
     void testGetMbis() {
         Patient patient = new Patient();

--- a/ab2d-filters/src/main/java/gov/cms/ab2d/filter/EOBLoadUtilities.java
+++ b/ab2d-filters/src/main/java/gov/cms/ab2d/filter/EOBLoadUtilities.java
@@ -1,6 +1,7 @@
 package gov.cms.ab2d.filter;
 
 import ca.uhn.fhir.context.FhirContext;
+import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -13,6 +14,7 @@ import java.io.Reader;
  * Loads Explanation of Benefits object from a file or reader
  */
 @Slf4j
+@UtilityClass
 public class EOBLoadUtilities {
     public static final String EOB_TYPE_CODE_SYS = "eob-type";
     public static final String EOB_TYPE_PART_D_CODE_VAL = "PDE";

--- a/ab2d-filters/src/main/java/gov/cms/ab2d/filter/EobUtils.java
+++ b/ab2d-filters/src/main/java/gov/cms/ab2d/filter/EobUtils.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.filter;
 
+import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
@@ -11,6 +12,7 @@ import static gov.cms.ab2d.filter.EOBLoadUtilities.EOB_TYPE_CODE_SYS;
 import static gov.cms.ab2d.filter.EOBLoadUtilities.EOB_TYPE_PART_D_CODE_VAL;
 
 @Slf4j
+@UtilityClass
 public class EobUtils {
     /**
      * Given a resource and the method name, return the result of calling the method

--- a/ab2d-filters/src/main/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmer.java
+++ b/ab2d-filters/src/main/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmer.java
@@ -2,6 +2,9 @@ package gov.cms.ab2d.filter;
 
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
 public class ExplanationOfBenefitTrimmer {
     /**
      * Return the trimmed version of the EOB. Currently, only R4 & DSTU3 are supported

--- a/ab2d-filters/src/main/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerR4.java
+++ b/ab2d-filters/src/main/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerR4.java
@@ -7,6 +7,8 @@ import org.hl7.fhir.r4.model.ExplanationOfBenefit;
 import org.hl7.fhir.r4.model.Extension;
 import org.hl7.fhir.r4.model.Identifier;
 
+import lombok.experimental.UtilityClass;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -121,16 +123,13 @@ import java.util.stream.Collectors;
  *     . modifierExtension
  *
  */
-public final class ExplanationOfBenefitTrimmerR4 {
+@UtilityClass
+public class ExplanationOfBenefitTrimmerR4 {
     public static final String ANESTHESIA_UNIT_COUNT = "https://bluebutton.cms.gov/resources/variables/carr_line_ansthsa_unit_cnt";
     public static final String RELATED_DIAGNOSIS_GROUP = "https://bluebutton.cms.gov/resources/variables/clm_drg_cd";
     public static final String PRICING_STATE = "https://bluebutton.cms.gov/resources/variables/dmerc_line_prcng_state_cd";
     public static final String SUPPLIER_TYPE = "https://bluebutton.cms.gov/resources/variables/dmerc_line_supplr_type_cd";
     public static final String NL_RECORD_IDENTIFICATION = "https://bluebutton.cms.gov/resources/variables/nch_near_line_rec_ident_cd";
-
-    private ExplanationOfBenefitTrimmerR4() {
-        throw new UnsupportedOperationException("This is a utility class so it cannot be not be instantiated");
-    }
 
     /**
      * Pass in an ExplanationOfBenefit, return the copy without the data

--- a/ab2d-filters/src/main/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerR4.java
+++ b/ab2d-filters/src/main/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerR4.java
@@ -121,12 +121,16 @@ import java.util.stream.Collectors;
  *     . modifierExtension
  *
  */
-public class ExplanationOfBenefitTrimmerR4 {
+public final class ExplanationOfBenefitTrimmerR4 {
     public static final String ANESTHESIA_UNIT_COUNT = "https://bluebutton.cms.gov/resources/variables/carr_line_ansthsa_unit_cnt";
     public static final String RELATED_DIAGNOSIS_GROUP = "https://bluebutton.cms.gov/resources/variables/clm_drg_cd";
     public static final String PRICING_STATE = "https://bluebutton.cms.gov/resources/variables/dmerc_line_prcng_state_cd";
     public static final String SUPPLIER_TYPE = "https://bluebutton.cms.gov/resources/variables/dmerc_line_supplr_type_cd";
     public static final String NL_RECORD_IDENTIFICATION = "https://bluebutton.cms.gov/resources/variables/nch_near_line_rec_ident_cd";
+
+    private ExplanationOfBenefitTrimmerR4() {
+        throw new UnsupportedOperationException("This is a utility class so it cannot be not be instantiated");
+    }
 
     /**
      * Pass in an ExplanationOfBenefit, return the copy without the data

--- a/ab2d-filters/src/main/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerSTU3.java
+++ b/ab2d-filters/src/main/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerSTU3.java
@@ -3,6 +3,8 @@ package gov.cms.ab2d.filter;
 import org.hl7.fhir.dstu3.model.ExplanationOfBenefit;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
+import lombok.experimental.UtilityClass;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -10,11 +12,8 @@ import java.util.stream.Collectors;
  * Cleans out data from a copy of an ExplanationOfBenefit object that we don't want
  * to forward to Part D providers
  */
-public final class ExplanationOfBenefitTrimmerSTU3 {
-
-    private ExplanationOfBenefitTrimmerSTU3() {
-        throw new UnsupportedOperationException("This is a utility class so it cannot be not be instantiated");
-    }
+@UtilityClass
+public class ExplanationOfBenefitTrimmerSTU3 {
 
     /**
      * Pass in an ExplanationOfBenefit, return the copy without the data

--- a/ab2d-filters/src/main/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerSTU3.java
+++ b/ab2d-filters/src/main/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerSTU3.java
@@ -10,7 +10,11 @@ import java.util.stream.Collectors;
  * Cleans out data from a copy of an ExplanationOfBenefit object that we don't want
  * to forward to Part D providers
  */
-public class ExplanationOfBenefitTrimmerSTU3 {
+public final class ExplanationOfBenefitTrimmerSTU3 {
+
+    private ExplanationOfBenefitTrimmerSTU3() {
+        throw new UnsupportedOperationException("This is a utility class so it cannot be not be instantiated");
+    }
 
     /**
      * Pass in an ExplanationOfBenefit, return the copy without the data

--- a/ab2d-filters/src/main/java/gov/cms/ab2d/filter/FilterEob.java
+++ b/ab2d-filters/src/main/java/gov/cms/ab2d/filter/FilterEob.java
@@ -2,15 +2,14 @@ package gov.cms.ab2d.filter;
 
 import org.hl7.fhir.instance.model.api.IBaseResource;
 
+import lombok.experimental.UtilityClass;
+
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
-public final class FilterEob {
-
-    private FilterEob() {
-        throw new UnsupportedOperationException("This is a utility class so it cannot be not be instantiated");
-    }
+@UtilityClass
+public class FilterEob {
 
     /**
      * Does all the filtering. If null is returned

--- a/ab2d-filters/src/main/java/gov/cms/ab2d/filter/FilterEob.java
+++ b/ab2d-filters/src/main/java/gov/cms/ab2d/filter/FilterEob.java
@@ -7,6 +7,11 @@ import java.util.List;
 import java.util.Optional;
 
 public final class FilterEob {
+
+    private FilterEob() {
+        throw new UnsupportedOperationException("This is a utility class so it cannot be not be instantiated");
+    }
+
     /**
      * Does all the filtering. If null is returned
      * @param resource - the resource to check

--- a/ab2d-filters/src/test/java/gov/cms/ab2d/filter/EOBLoadUtilitiesTest.java
+++ b/ab2d-filters/src/test/java/gov/cms/ab2d/filter/EOBLoadUtilitiesTest.java
@@ -36,15 +36,15 @@ public class EOBLoadUtilitiesTest {
         assertEquals(4, coding.size());
         org.hl7.fhir.dstu3.model.Coding cd = coding.stream().filter(c -> c.getCode().equals("professional")).findFirst().orElse(null);
         assertNotNull(cd);
-        assertEquals(cd.getSystem(), "http://hl7.org/fhir/ex-claimtype");
-        assertEquals(cd.getCode(), "professional");
-        assertEquals(cd.getDisplay(), "Professional");
+        assertEquals("http://hl7.org/fhir/ex-claimtype", cd.getSystem());
+        assertEquals("professional", cd.getCode());
+        assertEquals("Professional", cd.getDisplay());
     }
 
     @Test
     public void testResourceType() {
         ExplanationOfBenefit eobCarrier = (ExplanationOfBenefit) eobC;
-        assertEquals(eobCarrier.getResourceType(), org.hl7.fhir.dstu3.model.ResourceType.ExplanationOfBenefit);
+        assertEquals(org.hl7.fhir.dstu3.model.ResourceType.ExplanationOfBenefit, eobCarrier.getResourceType());
     }
 
     @Test
@@ -56,8 +56,8 @@ public class EOBLoadUtilitiesTest {
         ExplanationOfBenefit.DiagnosisComponent comp = diagnoses.stream()
                 .filter(c -> c.getSequence() == 2).findFirst().orElse(null);
         assertNotNull(comp);
-        assertEquals(comp.getDiagnosisCodeableConcept().getCoding().size(), 1);
-        assertEquals(comp.getDiagnosisCodeableConcept().getCoding().get(0).getCode(), "H8888");
+        assertEquals(1, comp.getDiagnosisCodeableConcept().getCoding().size());
+        assertEquals("H8888", comp.getDiagnosisCodeableConcept().getCoding().get(0).getCode());
     }
 
     @Test
@@ -65,15 +65,15 @@ public class EOBLoadUtilitiesTest {
         ExplanationOfBenefit eobSNF = (ExplanationOfBenefit) eobS;
         List<ExplanationOfBenefit.ProcedureComponent> procedures = eobSNF.getProcedure();
         assertNotNull(procedures);
-        assertEquals(procedures.size(), 1);
+        assertEquals(1, procedures.size());
         ExplanationOfBenefit.ProcedureComponent comp = procedures.get(0);
-        assertEquals(comp.getSequence(), 1);
+        assertEquals(1, comp.getSequence());
         assertNotNull(comp.getDate());
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US);
         Date expectedTime = sdf.parse("2016-01-16T00:00:00-0600");
         assertEquals(expectedTime.getTime(), comp.getDate().getTime());
-        assertEquals(comp.getProcedureCodeableConcept().getCoding().get(0).getSystem(), "http://hl7.org/fhir/sid/icd-9-cm");
-        assertEquals(comp.getProcedureCodeableConcept().getCoding().get(0).getCode(), "0TCCCCC");
+        assertEquals("http://hl7.org/fhir/sid/icd-9-cm", comp.getProcedureCodeableConcept().getCoding().get(0).getSystem());
+        assertEquals("0TCCCCC", comp.getProcedureCodeableConcept().getCoding().get(0).getCode());
     }
 
     @Test
@@ -82,8 +82,8 @@ public class EOBLoadUtilitiesTest {
         org.hl7.fhir.dstu3.model.Reference ref = eobSNF.getProvider();
         assertNotNull(ref);
         assertNotNull(ref.getIdentifier());
-        assertEquals(ref.getIdentifier().getSystem(), "https://bluebutton.cms.gov/resources/variables/prvdr_num");
-        assertEquals(ref.getIdentifier().getValue(), "299999");
+        assertEquals("https://bluebutton.cms.gov/resources/variables/prvdr_num", ref.getIdentifier().getSystem());
+        assertEquals("299999", ref.getIdentifier().getValue());
     }
 
     @Test
@@ -92,8 +92,8 @@ public class EOBLoadUtilitiesTest {
         org.hl7.fhir.dstu3.model.Reference ref = eobSNF.getOrganization();
         assertNotNull(ref);
         assertNotNull(ref.getIdentifier());
-        assertEquals(ref.getIdentifier().getSystem(), "http://hl7.org/fhir/sid/us-npi");
-        assertEquals(ref.getIdentifier().getValue(), "1111111111");
+        assertEquals("http://hl7.org/fhir/sid/us-npi", ref.getIdentifier().getSystem());
+        assertEquals("1111111111", ref.getIdentifier().getValue());
     }
 
     @Test
@@ -102,8 +102,8 @@ public class EOBLoadUtilitiesTest {
         org.hl7.fhir.dstu3.model.Reference ref = eobSNF.getFacility();
         assertNotNull(ref);
         assertNotNull(ref.getIdentifier());
-        assertEquals(ref.getIdentifier().getSystem(), "http://hl7.org/fhir/sid/us-npi");
-        assertEquals(ref.getIdentifier().getValue(), "1111111111");
+        assertEquals("http://hl7.org/fhir/sid/us-npi", ref.getIdentifier().getSystem());
+        assertEquals("1111111111", ref.getIdentifier().getValue());
     }
 
     @Test
@@ -116,7 +116,7 @@ public class EOBLoadUtilitiesTest {
                 .filter(c -> c.getValue().equalsIgnoreCase("900"))
                 .findFirst().orElse(null);
         assertNotNull(id);
-        assertEquals(id.getSystem(), "https://bluebutton.cms.gov/resources/identifier/claim-group");
+        assertEquals("https://bluebutton.cms.gov/resources/identifier/claim-group", id.getSystem());
     }
 
     @Test
@@ -128,11 +128,11 @@ public class EOBLoadUtilitiesTest {
         ExplanationOfBenefit.CareTeamComponent comp = careTeamComponents.stream()
                 .filter(c -> c.getSequence() == 2).findFirst().orElse(null);
         assertNotNull(comp);
-        assertEquals(comp.getProvider().getIdentifier().getSystem(), "http://hl7.org/fhir/sid/us-npi");
-        assertEquals(comp.getProvider().getIdentifier().getValue(), "3333333333");
-        assertEquals(comp.getRole().getCoding().get(0).getSystem(), "http://hl7.org/fhir/claimcareteamrole");
-        assertEquals(comp.getRole().getCoding().get(0).getCode(), "assist");
-        assertEquals(comp.getRole().getCoding().get(0).getDisplay(), "Assisting Provider");
+        assertEquals("http://hl7.org/fhir/sid/us-npi", comp.getProvider().getIdentifier().getSystem());
+        assertEquals("3333333333", comp.getProvider().getIdentifier().getValue());
+        assertEquals("http://hl7.org/fhir/claimcareteamrole", comp.getRole().getCoding().get(0).getSystem());
+        assertEquals("assist", comp.getRole().getCoding().get(0).getCode());
+        assertEquals("Assisting Provider", comp.getRole().getCoding().get(0).getDisplay());
     }
 
     @Test
@@ -141,12 +141,12 @@ public class EOBLoadUtilitiesTest {
         List<ExplanationOfBenefit.ItemComponent> components = eobCarrier.getItem();
         assertNotNull(components);
         assertEquals(components.size(), 1);
-        assertEquals(components.get(0).getCareTeamLinkId().get(0).getValue(), 2);
-        assertEquals(components.get(0).getQuantity().getValue().toString(), "1");
-        assertEquals(components.get(0).getSequence(), 6);
-        assertEquals(components.get(0).getService().getCoding().get(0).getSystem(), "https://bluebutton.cms.gov/resources/codesystem/hcpcs");
-        assertEquals(components.get(0).getService().getCoding().get(0).getVersion(), "5");
-        assertEquals(components.get(0).getService().getCoding().get(0).getCode(), "92999");
+        assertEquals(2, components.get(0).getCareTeamLinkId().get(0).getValue());
+        assertEquals("1", components.get(0).getQuantity().getValue().toString());
+        assertEquals(6, components.get(0).getSequence());
+        assertEquals("https://bluebutton.cms.gov/resources/codesystem/hcpcs", components.get(0).getService().getCoding().get(0).getSystem());
+        assertEquals("5", components.get(0).getService().getCoding().get(0).getVersion());
+        assertEquals("92999", components.get(0).getService().getCoding().get(0).getCode());
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
         Date d = sdf.parse("1999-10-27");
         org.hl7.fhir.dstu3.model.Period period = (org.hl7.fhir.dstu3.model.Period) components.get(0).getServiced();
@@ -155,13 +155,13 @@ public class EOBLoadUtilitiesTest {
 
         ExplanationOfBenefit eobSNF = (ExplanationOfBenefit) eobS;
         org.hl7.fhir.dstu3.model.CodeableConcept location = (org.hl7.fhir.dstu3.model.CodeableConcept) components.get(0).getLocation();
-        assertEquals(location.getCoding().get(0).getSystem(), "https://bluebutton.cms.gov/resources/variables/line_place_of_srvc_cd");
-        assertEquals(location.getCoding().get(0).getCode(), "11");
-        assertEquals(location.getCoding().get(0).getDisplay(), "Office. Location, other than a hospital, skilled nursing facility (SNF), military treatment facility, community health center, State or local public health clinic, or intermediate care facility (ICF), where the health professional routinely provides health examinations, diagnosis, and treatment of illness or injury on an ambulatory basis.");
+        assertEquals("https://bluebutton.cms.gov/resources/variables/line_place_of_srvc_cd", location.getCoding().get(0).getSystem());
+        assertEquals("11", location.getCoding().get(0).getCode());
+        assertEquals("Office. Location, other than a hospital, skilled nursing facility (SNF), military treatment facility, community health center, State or local public health clinic, or intermediate care facility (ICF), where the health professional routinely provides health examinations, diagnosis, and treatment of illness or injury on an ambulatory basis.", location.getCoding().get(0).getDisplay());
 
         List<ExplanationOfBenefit.ItemComponent> components2 = eobSNF.getItem();
         org.hl7.fhir.dstu3.model.Address location2 = (org.hl7.fhir.dstu3.model.Address) components2.get(0).getLocation();
-        assertEquals(location2.getState(), "FL");
+        assertEquals("FL", location2.getState());
     }
 
     @Test
@@ -173,7 +173,7 @@ public class EOBLoadUtilitiesTest {
                 // STU3
                 ExplanationOfBenefit benefit = (ExplanationOfBenefit) EOBLoadUtilities.getEOBFromReader(reader, context);
                 assertNotNull(benefit);
-                assertEquals(benefit.getPatient().getReference(), "Patient/-199900000022040");
+                assertEquals("Patient/-199900000022040", benefit.getPatient().getReference());
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/ab2d-filters/src/test/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerR4Test.java
+++ b/ab2d-filters/src/test/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerR4Test.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ExplanationOfBenefitTrimmerR4Test {
+class ExplanationOfBenefitTrimmerR4Test {
     private static final ExplanationOfBenefit EOB = new ExplanationOfBenefit();
     private static final Date SAMPLE_DATE = new Date();
     private static final String DUMMY_REF = "1234";

--- a/ab2d-filters/src/test/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerSTU3Test.java
+++ b/ab2d-filters/src/test/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerSTU3Test.java
@@ -14,6 +14,7 @@ import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -136,7 +137,7 @@ class ExplanationOfBenefitTrimmerSTU3Test {
         return items == null || items.isEmpty();
     }
 
-    private void printItOut(String file) {
+    private String printItOut(String file) {
         IParser jsonParser = context.newJsonParser().setPrettyPrint(true);
 
         IBaseResource eCarrier = ExplanationOfBenefitTrimmerSTU3.getBenefit(
@@ -144,11 +145,13 @@ class ExplanationOfBenefitTrimmerSTU3Test {
 
         String result = jsonParser.encodeResourceToString(eCarrier);
         System.out.println(result);
+        return result;
     }
 
     @Test
-    void demo1() {
-        printItOut("eobdata/EOB-for-Carrier-Claims.json");
+    void testPrintItOut() {
+        String result = printItOut("eobdata/EOB-for-Carrier-Claims.json");
+        assertNotEquals("", result);
     }
 
     @Test

--- a/ab2d-filters/src/test/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerSTU3Test.java
+++ b/ab2d-filters/src/test/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerSTU3Test.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ExplanationOfBenefitTrimmerSTU3Test {
+class ExplanationOfBenefitTrimmerSTU3Test {
     private static IBaseResource eobResource = null;
     private static FhirContext context = FhirContext.forDstu3();
 
@@ -26,7 +26,7 @@ public class ExplanationOfBenefitTrimmerSTU3Test {
     }
 
     @Test
-    public void testEmptyList() {
+    void testEmptyList() {
         ExplanationOfBenefitTrimmerSTU3.clearOutList(null);
         List<Integer> list = new ArrayList<>();
         ExplanationOfBenefitTrimmerSTU3.clearOutList(list);
@@ -38,7 +38,7 @@ public class ExplanationOfBenefitTrimmerSTU3Test {
     }
 
     @Test
-    public void validateEmpty() {
+    void validateEmpty() {
         ExplanationOfBenefit eobCarrier = (ExplanationOfBenefit) eobResource;
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
         assertNull(ExplanationOfBenefitTrimmerSTU3.getBenefit(null));
@@ -88,7 +88,7 @@ public class ExplanationOfBenefitTrimmerSTU3Test {
     }
 
     @Test
-    public void testItemValues() {
+    void testItemValues() {
         ExplanationOfBenefit eobCarrier = (ExplanationOfBenefit) eobResource;
         if (eobCarrier.getItem() != null) {
             for (var item : eobCarrier.getItem()) {

--- a/ab2d-filters/src/test/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerSTU3Test.java
+++ b/ab2d-filters/src/test/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerSTU3Test.java
@@ -38,20 +38,46 @@ class ExplanationOfBenefitTrimmerSTU3Test {
     }
 
     @Test
-    void validateEmpty() {
-        ExplanationOfBenefit eobCarrier = (ExplanationOfBenefit) eobResource;
+    void validateDefaultEobStartingBillablePeriod() {
+        ExplanationOfBenefit eob = (ExplanationOfBenefit) eobResource;
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd", Locale.US);
+
+        assertEquals("1999-10-27", sdf.format(eob.getBillablePeriod().getStart()));
+        assertEquals("1999-10-27", sdf.format(eob.getBillablePeriod().getEnd()));
+    }
+
+    @Test
+    void validateDefaultEobClaimEmpty() {
+        ExplanationOfBenefit eob = (ExplanationOfBenefit) eobResource;
+
+        assertNull(eob.getClaim().getId());
+        assertNull(eob.getClaimTarget().getId());
+        assertNull(eob.getClaimResponse().getId());
+        assertNull(eob.getClaimResponseTarget().getId());
+    }
+
+    @Test
+    void validateDefaultEobFieldsEmpty() {
+        ExplanationOfBenefit eob = (ExplanationOfBenefit) eobResource;
+
+        assertTrue(isNullOrEmpty(eob.getProcessNote()));
+        assertTrue(isNullOrEmpty(eob.getBenefitBalance()));
+        assertTrue(isNullOrEmpty(eob.getAddItem()));
+        assertTrue(isNullOrEmpty(eob.getInformation()));
+        assertTrue(isNullOrEmpty(eob.getRelated()));
+        assertTrue(eob.getPatientTarget().isEmpty());
+        assertTrue(StringUtils.isBlank(eob.getEnterer().getReference()));
+        assertTrue(eob.getEntererTarget().getName().isEmpty());
+        assertEquals(0, eob.getPrecedence());
+    }
+
+    @Test
+    void validateDefaultEobFieldsNull() {
+        ExplanationOfBenefit eobCarrier = (ExplanationOfBenefit) eobResource;
         assertNull(ExplanationOfBenefitTrimmerSTU3.getBenefit(null));
         // Since getting a patient target creates a new one, make sure the object is empty
-        assertTrue(eobCarrier.getPatientTarget().getIdentifier().isEmpty());
-        assertNull(eobCarrier.getPatientTarget().getId());
-        assertFalse(eobCarrier.getPatientTarget().getActive());
-        assertNull(eobCarrier.getPatientTarget().getBirthDate());
-        assertEquals("1999-10-27", sdf.format(eobCarrier.getBillablePeriod().getStart()));
-        assertEquals("1999-10-27", sdf.format(eobCarrier.getBillablePeriod().getEnd()));
+
         assertNull(eobCarrier.getCreated());
-        assertTrue(StringUtils.isBlank(eobCarrier.getEnterer().getReference()));
-        assertTrue(eobCarrier.getEntererTarget().getName().isEmpty());
         assertNull(eobCarrier.getInsurer().getId());
         assertNull(eobCarrier.getInsurerTarget().getId());
         assertNull(eobCarrier.getProviderTarget().getId());
@@ -59,32 +85,22 @@ class ExplanationOfBenefitTrimmerSTU3Test {
         assertNull(eobCarrier.getReferral().getId());
         assertNull(eobCarrier.getReferralTarget().getId());
         assertNull(eobCarrier.getFacilityTarget().getId());
-        assertNull(eobCarrier.getClaim().getId());
-        assertNull(eobCarrier.getClaimTarget().getId());
-        assertNull(eobCarrier.getClaimResponse().getId());
-        assertNull(eobCarrier.getClaimResponseTarget().getId());
         assertNull(eobCarrier.getOutcome().getId());
         assertNull(eobCarrier.getDisposition());
-        assertTrue(isNullOrEmpty(eobCarrier.getRelated()));
         assertNull(eobCarrier.getPrescription().getId());
         assertNull(eobCarrier.getPrescriptionTarget());
         assertNull(eobCarrier.getOriginalPrescription().getId());
         assertNull(eobCarrier.getOriginalPrescriptionTarget().getId());
         assertNull(eobCarrier.getPayee().getId());
-        assertTrue(isNullOrEmpty(eobCarrier.getInformation()));
-        assertEquals(0, eobCarrier.getPrecedence());
         assertNull(eobCarrier.getInsurance().getId());
         assertNull(eobCarrier.getAccident().getId());
         assertNull(eobCarrier.getEmploymentImpacted().getId());
         assertNull(eobCarrier.getHospitalization().getId());
-        assertTrue(isNullOrEmpty(eobCarrier.getAddItem()));
         assertNull(eobCarrier.getTotalCost().getId());
         assertNull(eobCarrier.getUnallocDeductable().getId());
         assertNull(eobCarrier.getTotalBenefit().getId());
         assertNull(eobCarrier.getPayment().getId());
         assertNull(eobCarrier.getForm().getId());
-        assertTrue(isNullOrEmpty(eobCarrier.getProcessNote()));
-        assertTrue(isNullOrEmpty(eobCarrier.getBenefitBalance()));
     }
 
     @Test

--- a/ab2d-filters/src/test/java/gov/cms/ab2d/filter/FilterOutByDateTest.java
+++ b/ab2d-filters/src/test/java/gov/cms/ab2d/filter/FilterOutByDateTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-public class FilterOutByDateTest {
+class FilterOutByDateTest {
     private transient ThreadLocal<SimpleDateFormat> sdf = new ThreadLocal<>() {
         @Override
         protected SimpleDateFormat initialValue() {

--- a/ab2d-filters/src/test/java/gov/cms/ab2d/filter/FilterTest.java
+++ b/ab2d-filters/src/test/java/gov/cms/ab2d/filter/FilterTest.java
@@ -12,7 +12,7 @@ import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class FilterTest {
+class FilterTest {
     @Test
     void testFilter() throws ParseException {
         assertTrue(FilterEob.filter(null, null, null, null, true).isEmpty());

--- a/ab2d-properties-client/src/main/java/gov/cms/ab2d/properties/client/PropertiesClientImpl.java
+++ b/ab2d-properties-client/src/main/java/gov/cms/ab2d/properties/client/PropertiesClientImpl.java
@@ -96,9 +96,7 @@ public class PropertiesClientImpl implements PropertiesClient {
     public void deleteProperty(String key) {
         try {
             HttpResponse<String> result = Unirest.delete(url + "/properties/" + key).asString();
-            if (result != null && result.getBody() != null && result.getBody().equalsIgnoreCase("true")) {
-                return;
-            } else {
+            if (result == null || result.getBody() == null || !result.getBody().equalsIgnoreCase("true")) {
                 throw new PropertyNotFoundException("Unable to delete " + key);
             }
         } catch (Exception ex) {

--- a/ab2d-properties-client/src/test/java/gov/cms/ab2d/properties/client/PropertiesClientTest.java
+++ b/ab2d-properties-client/src/test/java/gov/cms/ab2d/properties/client/PropertiesClientTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class PropertiesClientTest {
+class PropertiesClientTest {
     @Disabled
     @Test
     void testGettingProperties() {

--- a/ab2d-properties-client/src/test/java/gov/cms/ab2d/properties/client/ProperyServiceMockTest.java
+++ b/ab2d-properties-client/src/test/java/gov/cms/ab2d/properties/client/ProperyServiceMockTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class ProperyServiceMockTest {
+class ProperyServiceMockTest {
     class PropertiesClientImplMock extends PropertiesClientImpl {
         @Override
         public String getFromEnvironment() {


### PR DESCRIPTION
A copy of PR 372 to refresh jenkins as it is broken on 372.

## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-5907
https://jira.cms.gov/browse/AB2D-6040

## 🛠 Changes

Addresses codesmells under the following severities (Note: some lines listed here may cover multiple smells):

Critical:
Add a nested comment to explain why JobSummaryEvent constructor is blank
Define a variable instead of duplicating string literal "OperationOutcome"
Define a constant instead of duplicating string literal "setValue"
Define a constant instead of duplicating string literal "Extension"
Define constants instead of duplicating string literals in BundleUtils
Define a constant instead of duplicating the literals "IncludeIdentifiers" and "mbi"
Remove Redundant Jump in PropertiesClientImpl

Major:
Refactor test case to reduce number of assertions in ExplanationOfBenefitTrimmerSTU3Test
Swap assertion expected and actual values across multiple files
Make non-static constant fields static
Add private constructor to public utility class FilterEob
Add private constructor to Utility class ExplanationOfBenefitTrimmerStu3
Add private constructor to Utility class ExplanationOfBenefitTrimmerR4
Add private constructor to Utility class ExplanationOfBenefitTrimmer
'description' hides the field declared on line 18. (removed line 34 as it was unnecessarily redundant)
Change the visibility of constructors in LoggableEvent to protected
Remove fields that hide other fields in LoggableEvent. (removed multiple unnecessarily redundant lines)
Change the visibility of constructor in SQSMessages to protected
Swap arguments in assertions to the correct order in SendSqsEventTest
Add private constructor to Utility class Versions
Add private constructor to Utility class EobLoadUtilities


Info:
Remove Public Modifier in PropertiesServiceMockTest
Remove Public Modifier in PropertiesClientTest
Remove Public Modifier in FilterTest
Remove Public Modifier in FilterOutByDateTest
Remove Public Modifier for ExplanationOfBenefitTrimmerSTU3Test
Remove Public Modifiers for Test cases in ExplanationOfBenefitTrimmerSTU3Test
Remove Public Modifier in ExplanationOfBenefitTrimmerR4Test

---------------------------------------------------------------------------------------------------------------

Add a nested comment to explain why JobSummaryEvent constructor is blank:
<img width="873" alt="Screenshot 2024-03-27 at 10 41 47 AM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/380e6e3b-9633-4302-9855-29b078ba9477">

Define a variable instead of duplicating string literal "OperationOutcome":
<img width="874" alt="Screenshot 2024-03-27 at 10 33 16 AM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/549f4594-2ab0-4932-b92f-ff19a75e01a9">

Define a constant instead of duplicating string literal "setValue":
<img width="903" alt="Screenshot 2024-03-27 at 10 20 21 AM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/2c363253-2f4b-4d27-99e4-6a2e21d60500">

Define a constant instead of duplicating string literal "Extension":
<img width="882" alt="Screenshot 2024-03-26 at 5 00 35 PM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/1c81fc08-77dc-404c-825b-79a01be8250c">

Define constants instead of duplicating string literals in BundleUtils:
<img width="868" alt="Screenshot 2024-03-26 at 4 58 28 PM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/ebb21f51-d751-4df6-b17b-eedb1781a20d">

Define a constant instead of duplicating the literals "IncludeIdentifiers" and "mbi" 3 times:
<img width="978" alt="Screenshot 2024-03-26 at 4 46 36 PM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/800c8aeb-3fd2-4db7-9f8c-1f1aeb5dcbf2">

Remove Public Modifier in PropertiesServiceMockTest: 
<img width="925" alt="Screenshot 2024-03-25 at 11 53 35 AM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/33d39be2-2029-4781-94bd-a5decc4437a3">

Remove Public Modifier in PropertiesClientTest:
<img width="969" alt="Screenshot 2024-03-26 at 11 42 19 AM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/63919a25-3745-462f-96f3-327b9b04a61b">

Remove Public Modifier in FilterTest:
<img width="971" alt="Screenshot 2024-03-26 at 11 44 37 AM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/c6714af0-56ca-49e6-9bc1-0d2b251fa59b">

Remove Public Modifier in FilterOutByDateTest:
<img width="974" alt="Screenshot 2024-03-26 at 11 46 29 AM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/ac0cff8f-6833-4be9-8ae2-57d1a63c00f1">

Remove Public Modifier for ExplanationOfBenefitTrimmerSTU3Test:
<img width="971" alt="Screenshot 2024-03-26 at 11 48 25 AM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/fb2ae05e-b378-4efa-b384-b9fafc732b70">

Removed Public Modifiers for Test cases in ExplanationOfBenefitTrimmerSTU3Test:
<img width="982" alt="Screenshot 2024-03-26 at 11 53 00 AM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/25ca7ce1-e0ca-4913-b6c9-fdbf8db7016e">
<img width="984" alt="Screenshot 2024-03-26 at 11 53 14 AM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/713b8bf6-4024-4b0c-be45-473e41f25bb0">
<img width="981" alt="Screenshot 2024-03-26 at 11 53 24 AM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/ef8f944c-942f-4b7a-97a2-903d1298e707">

Remove Redundant Jump in PropertiesClientImpl:
<img width="862" alt="Screenshot 2024-03-25 at 11 54 01 AM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/30145a23-21e0-4651-af04-44d7c39a7128">

Remove Public Modifier for ExplanationOfBenefitR4Test:
<img width="864" alt="Screenshot 2024-04-02 at 9 49 46 AM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/84442d59-2a36-4a26-b1fa-fa281f5412ba">

Add private constructor to public utility class FilterEob:
<img width="974" alt="Screenshot 2024-04-17 at 11 20 50 AM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/789e6094-2d04-4982-966b-52bce66c377d">

Add private constructor to utility class ExplanationOfBenefitTrimmerStu3:
<img width="968" alt="Screenshot 2024-04-17 at 11 29 23 AM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/533f064f-2efd-4927-9029-7b9a7b1eefe5">

'description' hides the field declared on line 18. (removed line 34 as it was unnecessarily redundant):
<img width="972" alt="Screenshot 2024-04-19 at 9 45 22 AM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/6b3f91fd-18d2-462a-91ed-b711568abc36">

Change the visibility of constructors in LoggableEvent to protected:
<img width="972" alt="Screenshot 2024-04-19 at 9 52 19 AM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/f3a80f64-6c40-4fd9-8cea-1938e6f955a1">
<img width="966" alt="Screenshot 2024-04-19 at 9 55 31 AM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/f8fed5ec-6992-4451-a2dc-88ec44627826">

Remove fields that hide other fields in LoggableEvent. (removed multiple unnecessarily redundant lines):
<img width="975" alt="Screenshot 2024-04-19 at 10 00 08 AM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/450da731-55d9-48f3-aaae-ee1b877986e8">

Change the visibility of constructor in SQSMessages to protected:
<img width="977" alt="Screenshot 2024-04-19 at 10 07 24 AM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/af9e4665-4abc-4c66-a4d3-5168182c3486">

Swap arguments in assertions to the correct order in SendSqsEventTest:
<img width="972" alt="Screenshot 2024-04-19 at 10 09 53 AM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/02fc2298-695d-451a-a4f5-44406bae2c39">

Add private constructor to Utility class Versions (Added UtilityClass Annotation):
<img width="972" alt="Screenshot 2024-04-19 at 10 16 23 AM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/f4432f4e-3fd3-41b3-87b1-3dbc01a49230">

Add private constructor to Utility class EobLoadUtilities (Added UtilityClass Annotation):
<img width="969" alt="Screenshot 2024-04-19 at 10 23 49 AM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/a65a8bbd-1e65-409c-8e47-26401a29aa17">


## ✅ Acceptance Validation

Built Successfully on local environment:
<img width="303" alt="Screenshot 2024-03-27 at 2 44 35 PM" src="https://github.com/CMSgov/AB2D-Libs/assets/87499456/c430a6d1-f51d-4f86-86f2-8f877917c8ee">

TODO:
Redeploy all of AB2D with updated library versions after this change and test on lower environments.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
