### PR TITLE
[AB2D-5916, 6054] Set us-east-1 region on SNSConfig

### DIFF
--- a/ab2d-sns-client/src/main/java/gov/cms/ab2d/snsclient/clients/SNSConfig.java
+++ b/ab2d-sns-client/src/main/java/gov/cms/ab2d/snsclient/clients/SNSConfig.java
@@ -1,6 +1,7 @@
 package gov.cms.ab2d.snsclient.clients;
 
 import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.sns.AmazonSNSClient;
 import com.amazonaws.services.sns.AmazonSNSClientBuilder;
 import gov.cms.ab2d.eventclient.config.Ab2dEnvironment;
@@ -29,6 +30,7 @@ public class SNSConfig {
                         ? AmazonSNSClient.builder()
                         .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(url, region))
                         : AmazonSNSClientBuilder.standard()
+                        .withRegion(Regions.US_EAST_1)
         ).build();
     }
 

--- a/ab2d-sns-client/src/test/java/gov/cms/ab2d/snsclient/config/SendSnsTest.java
+++ b/ab2d-sns-client/src/test/java/gov/cms/ab2d/snsclient/config/SendSnsTest.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.snsclient.config;
 
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.sns.AmazonSNSClient;
 import com.amazonaws.services.sns.AmazonSNSClientBuilder;
 import gov.cms.ab2d.eventclient.config.Ab2dEnvironment;
@@ -49,6 +50,8 @@ class SendSnsTest {
                 AmazonSNSClientBuilder builder = Mockito.mock(AmazonSNSClientBuilder.class);
                 utilities.when(AmazonSNSClientBuilder::standard)
                         .thenReturn(builder);
+                Mockito.when(builder.withRegion(Regions.US_EAST_1))
+                    .thenReturn(builder);
                 Mockito.when(builder.build())
                         .thenReturn(sns);
                 SNSConfig snsConfig = new SNSConfig();

--- a/build.gradle
+++ b/build.gradle
@@ -22,14 +22,14 @@ ext {
             : System.getenv()['ARTIFACTORY_PASSWORD']
 
     // AB2D libraries
-    fhirVersion='1.2.1'
-    bfdVersion='2.1.1'
-    aggregatorVersion='1.3.1'
-    filtersVersion='1.9.1'
-    eventClientVersion='1.12.2'
-    propertiesClientVersion='1.2.1'
-    contractClientVersion='1.2.1'
-    snsClientVersion='0.2.1'
+    fhirVersion='1.2.3'
+    bfdVersion='2.1.3'
+    aggregatorVersion='1.3.3'
+    filtersVersion='1.9.3'
+    eventClientVersion='1.12.4'
+    propertiesClientVersion='1.2.3'
+    contractClientVersion='1.2.3'
+    snsClientVersion='0.2.3'
 
     sourcesRepo = 'ab2d-maven-repo'
     deployerRepo = 'ab2d-main'


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-5916
https://jira.cms.gov/browse/AB2D-6054

## 🛠 Changes

Set SNSClient Region to us-east-1 to troubleshoot IMDSV2 issues

## ℹ️ Context for reviewers

We need to specify a region in order to use IMDSV2. Hard coding it here isn't ideal, but according to platform, is the only realistic option. This PR is just setting it on SNSConfig as that is where we are seeing the error. It is likely we will need to do the same thing for SQSConfig, but I wanted to test this making one change at a time.

## ✅ Acceptance Validation

Builds locally. Will be deployed to IMPL with new libs versions to test.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
