### PR TITLE
[AB2D-6150] increase `ab2d-properties-client` test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # AB2D LIBS
 
-## testing change
-
 This repository stores all dependencies for AB2D.
-Confirm you have your gradle configured, so you can connect to the CMS repository locally.
+Confirm you have your gradle configured, so you can connect to the CMS repository locally. 
 
 ## Locally Build
 ```
@@ -12,7 +10,7 @@ gradle -b build.gradle
 
 ## Publishing
 To publish any changes, You can force an update by using the jenkins_force_publish file.
-New jars won't be published unless you change the library version to one that does not exist.
+New jars won't be published unless you change the library version to one that does not exist. 
 Example of version for bfd in /ab2d-bfd/build.gradle
 ```
 version = '1.0'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # AB2D LIBS
 
+## testing change
+
 This repository stores all dependencies for AB2D.
-Confirm you have your gradle configured, so you can connect to the CMS repository locally. 
+Confirm you have your gradle configured, so you can connect to the CMS repository locally.
 
 ## Locally Build
 ```
@@ -10,7 +12,7 @@ gradle -b build.gradle
 
 ## Publishing
 To publish any changes, You can force an update by using the jenkins_force_publish file.
-New jars won't be published unless you change the library version to one that does not exist. 
+New jars won't be published unless you change the library version to one that does not exist.
 Example of version for bfd in /ab2d-bfd/build.gradle
 ```
 version = '1.0'

--- a/ab2d-properties-client/src/main/java/gov/cms/ab2d/properties/client/PropertiesClientImpl.java
+++ b/ab2d-properties-client/src/main/java/gov/cms/ab2d/properties/client/PropertiesClientImpl.java
@@ -13,6 +13,10 @@ import java.util.List;
 public class PropertiesClientImpl implements PropertiesClient {
     @Getter
     private String url = "http://localhost:8060";
+
+    @Getter
+    private String configFileName = "application.properties";
+
     private static final String JSON = "application/json";
     private static final String ACCEPT = "accept";
 
@@ -28,7 +32,7 @@ public class PropertiesClientImpl implements PropertiesClient {
         }
         PropertiesConfiguration config = new PropertiesConfiguration();
         try {
-            config.load("application.properties");
+            config.load(getConfigFileName());
             String configUrl = config.getString("properties.service.url");
             if (StringUtils.isNotEmpty(configUrl)) {
                 url = configUrl;
@@ -50,7 +54,7 @@ public class PropertiesClientImpl implements PropertiesClient {
                     .asObject(new GenericType<List<Property>>() {
                     });
             List<Property> values = response.getBody();
-            if (values ==  null) {
+            if (values == null) {
                 throw new PropertyNotFoundException("Cannot find the list of properties");
             }
             return values;

--- a/ab2d-properties-client/src/test/java/gov/cms/ab2d/properties/client/ProperyServiceMockTest.java
+++ b/ab2d-properties-client/src/test/java/gov/cms/ab2d/properties/client/ProperyServiceMockTest.java
@@ -37,7 +37,6 @@ class ProperyServiceMockTest {
         List<Property> propertiesToReturn = List.of(new Property("a.key", "a.value"), new Property("b.key", "b.value"));
         JSONArray jsonArray = new JSONArray(propertiesToReturn);
         stubFor(get(urlEqualTo("/properties")).willReturn(aResponse().withBody(jsonArray.toString())));
-        System.out.println(propertiesToReturn.get(0).toString());
         stubFor(get(urlEqualTo("/properties/a.key"))
                 .willReturn(aResponse().withBody("{ \"key\": \"a.key\", \"value\": \"a.value\"}")));
         stubFor(post(urlEqualTo("/properties"))
@@ -75,6 +74,20 @@ class ProperyServiceMockTest {
     void testImpl() {
         PropertiesClientImplMock mock = new PropertiesClientImplMock();
         assertEquals("http://localhost:8065", mock.getUrl());
+    }
+
+    class PropertiesClientImplMockConfig extends PropertiesClientImpl {
+        @Override
+        public String getConfigFileName() {
+            return "does.not.exist";
+        }
+    }
+
+    @Test
+    void testConfigUrl() {
+        // There's nothing to test here, with just want to assert that the method
+        // doesn't throw an exception
+        new PropertiesClientImplMockConfig();
     }
 
     @Test

--- a/ab2d-properties-client/src/test/java/gov/cms/ab2d/properties/client/ProperyServiceMockTest.java
+++ b/ab2d-properties-client/src/test/java/gov/cms/ab2d/properties/client/ProperyServiceMockTest.java
@@ -112,7 +112,7 @@ class ProperyServiceMockTest {
     }
 
     @Test
-    void testDeleteTrueFalse() {
+    void testDeleteCases() {
         int port = 8066;
         PropertiesClientImpl impl = new PropertiesClientImpl("http://localhost:" + port);
         WireMockServer wireMockServer = new WireMockServer(port);
@@ -127,6 +127,10 @@ class ProperyServiceMockTest {
         // test running delete with true
         stubFor(delete(urlEqualTo("/properties/one")).willReturn(aResponse().withBody("true")));
         impl.deleteProperty("one");
+
+        // test running delete with null (presumably)
+        stubFor(delete(urlEqualTo("/properties/one")).willReturn(aResponse()));
+        assertThrows(PropertyNotFoundException.class, () -> impl.deleteProperty("one"));
 
         wireMockServer.stop();
     }

--- a/ab2d-properties-client/src/test/java/gov/cms/ab2d/properties/client/ProperyServiceMockTest.java
+++ b/ab2d-properties-client/src/test/java/gov/cms/ab2d/properties/client/ProperyServiceMockTest.java
@@ -90,14 +90,6 @@ class ProperyServiceMockTest {
         stubFor(get(urlEqualTo("/properties/a.key")).willReturn(aResponse().withStatus(520)));
         stubFor(post(urlEqualTo("/properties")).willReturn((aResponse().withStatus(404))));
         stubFor(delete(urlEqualTo("/properties/one")).willReturn(aResponse().withBody("false")));
-        // stubFor(post(urlEqualTo("/properties"))
-        // .willReturn(aResponse().withBody("{ \"key\": \"one\", \"value\":
-        // \"two\"}")));
-        // stubFor(get(urlEqualTo("/properties/one")).willReturn(aResponse().withBody("{
-        // \"key\": \"one\", \"value\": \"two\"}")));
-        // stubFor(get(urlEqualTo("/properties/bogus")).willReturn(aResponse().withStatus(404).withBody("{
-        // \"key\": \"null\", \"value\": \"null\"}")));
-        // stubFor(delete(urlEqualTo("/properties/one")).willReturn(aResponse().withBody("true")));
 
         assertThrows(PropertyNotFoundException.class, () -> impl.getAllProperties());
 

--- a/ab2d-properties-client/src/test/java/gov/cms/ab2d/properties/client/ProperyServiceMockTest.java
+++ b/ab2d-properties-client/src/test/java/gov/cms/ab2d/properties/client/ProperyServiceMockTest.java
@@ -38,11 +38,14 @@ class ProperyServiceMockTest {
         JSONArray jsonArray = new JSONArray(propertiesToReturn);
         stubFor(get(urlEqualTo("/properties")).willReturn(aResponse().withBody(jsonArray.toString())));
         System.out.println(propertiesToReturn.get(0).toString());
-        stubFor(get(urlEqualTo("/properties/a.key")).willReturn(aResponse().withBody("{ \"key\": \"a.key\", \"value\": \"a.value\"}")));
+        stubFor(get(urlEqualTo("/properties/a.key"))
+                .willReturn(aResponse().withBody("{ \"key\": \"a.key\", \"value\": \"a.value\"}")));
         stubFor(post(urlEqualTo("/properties"))
                 .willReturn(aResponse().withBody("{ \"key\": \"one\", \"value\": \"two\"}")));
-        stubFor(get(urlEqualTo("/properties/one")).willReturn(aResponse().withBody("{ \"key\": \"one\", \"value\": \"two\"}")));
-        stubFor(get(urlEqualTo("/properties/bogus")).willReturn(aResponse().withStatus(404).withBody("{ \"key\": \"null\", \"value\": \"null\"}")));
+        stubFor(get(urlEqualTo("/properties/one"))
+                .willReturn(aResponse().withBody("{ \"key\": \"one\", \"value\": \"two\"}")));
+        stubFor(get(urlEqualTo("/properties/bogus"))
+                .willReturn(aResponse().withStatus(404).withBody("{ \"key\": \"null\", \"value\": \"null\"}")));
         stubFor(delete(urlEqualTo("/properties/one")).willReturn(aResponse().withBody("true")));
 
         List<Property> properties = impl.getAllProperties();
@@ -87,11 +90,14 @@ class ProperyServiceMockTest {
         stubFor(get(urlEqualTo("/properties/a.key")).willReturn(aResponse().withStatus(520)));
         stubFor(post(urlEqualTo("/properties")).willReturn((aResponse().withStatus(404))));
         stubFor(delete(urlEqualTo("/properties/one")).willReturn(aResponse().withBody("false")));
-        //stubFor(post(urlEqualTo("/properties"))
-         //       .willReturn(aResponse().withBody("{ \"key\": \"one\", \"value\": \"two\"}")));
-        //stubFor(get(urlEqualTo("/properties/one")).willReturn(aResponse().withBody("{ \"key\": \"one\", \"value\": \"two\"}")));
-        //stubFor(get(urlEqualTo("/properties/bogus")).willReturn(aResponse().withStatus(404).withBody("{ \"key\": \"null\", \"value\": \"null\"}")));
-        //stubFor(delete(urlEqualTo("/properties/one")).willReturn(aResponse().withBody("true")));
+        // stubFor(post(urlEqualTo("/properties"))
+        // .willReturn(aResponse().withBody("{ \"key\": \"one\", \"value\":
+        // \"two\"}")));
+        // stubFor(get(urlEqualTo("/properties/one")).willReturn(aResponse().withBody("{
+        // \"key\": \"one\", \"value\": \"two\"}")));
+        // stubFor(get(urlEqualTo("/properties/bogus")).willReturn(aResponse().withStatus(404).withBody("{
+        // \"key\": \"null\", \"value\": \"null\"}")));
+        // stubFor(delete(urlEqualTo("/properties/one")).willReturn(aResponse().withBody("true")));
 
         assertThrows(PropertyNotFoundException.class, () -> impl.getAllProperties());
 
@@ -104,4 +110,34 @@ class ProperyServiceMockTest {
 
         wireMockServer.stop();
     }
+
+    @Test
+    void testDeleteTrueFalse() {
+        int port = 8066;
+        PropertiesClientImpl impl = new PropertiesClientImpl("http://localhost:" + port);
+        WireMockServer wireMockServer = new WireMockServer(port);
+        wireMockServer.start();
+
+        configureFor("localhost", port);
+
+        // test running delete with false
+        stubFor(delete(urlEqualTo("/properties/one")).willReturn(aResponse().withBody("false")));
+        assertThrows(PropertyNotFoundException.class, () -> impl.deleteProperty("one"));
+
+        // test running delete with true
+        stubFor(delete(urlEqualTo("/properties/one")).willReturn(aResponse().withBody("true")));
+        impl.deleteProperty("one");
+
+        wireMockServer.stop();
+    }
+
+    @Test
+    void testErrorsWithoutMock() {
+        PropertiesClientImpl impl = new PropertiesClientImpl();
+        assertThrows(PropertyNotFoundException.class, () -> impl.getAllProperties());
+        assertThrows(PropertyNotFoundException.class, () -> impl.getProperty("a.key"));
+        assertThrows(PropertyNotFoundException.class, () -> impl.setProperty("one", "two"));
+        assertThrows(PropertyNotFoundException.class, () -> impl.deleteProperty("one"));
+    }
+
 }

--- a/ab2d-properties-client/src/test/java/gov/cms/ab2d/properties/client/ProperyServiceMockTest.java
+++ b/ab2d-properties-client/src/test/java/gov/cms/ab2d/properties/client/ProperyServiceMockTest.java
@@ -18,10 +18,17 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ProperyServiceMockTest {
-    class PropertiesClientImplMock extends PropertiesClientImpl {
+    class PropertiesClientImplMockEnv extends PropertiesClientImpl {
         @Override
         public String getFromEnvironment() {
             return "http://localhost:8065";
+        }
+    }
+
+    class PropertiesClientImplMockConfig extends PropertiesClientImpl {
+        @Override
+        public String getConfigFileName() {
+            return "does.not.exist";
         }
     }
 
@@ -71,23 +78,15 @@ class ProperyServiceMockTest {
     }
 
     @Test
-    void testImpl() {
-        PropertiesClientImplMock mock = new PropertiesClientImplMock();
+    void testMockEnv() {
+        PropertiesClientImplMockEnv mock = new PropertiesClientImplMockEnv();
         assertEquals("http://localhost:8065", mock.getUrl());
     }
 
-    class PropertiesClientImplMockConfig extends PropertiesClientImpl {
-        @Override
-        public String getConfigFileName() {
-            return "does.not.exist";
-        }
-    }
-
     @Test
-    void testConfigUrl() {
-        // There's nothing to test here, with just want to assert that the method
-        // doesn't throw an exception
-        new PropertiesClientImplMockConfig();
+    void testMockConfig() {
+        PropertiesClientImplMockConfig mock = new PropertiesClientImplMockConfig();
+        assertEquals("http://localhost:8060", mock.getUrl());
     }
 
     @Test

--- a/ab2d-properties-client/src/test/java/gov/cms/ab2d/properties/client/ProperyServiceMockTest.java
+++ b/ab2d-properties-client/src/test/java/gov/cms/ab2d/properties/client/ProperyServiceMockTest.java
@@ -13,6 +13,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -130,7 +131,7 @@ class ProperyServiceMockTest {
 
         // test running delete with true
         stubFor(delete(urlEqualTo("/properties/one")).willReturn(aResponse().withBody("true")));
-        impl.deleteProperty("one");
+        assertDoesNotThrow(() -> impl.deleteProperty("one"));
 
         // test running delete with null (presumably)
         stubFor(delete(urlEqualTo("/properties/one")).willReturn(aResponse()));

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ ext {
     aggregatorVersion='1.3.4'
     filtersVersion='1.9.4'
     eventClientVersion='1.12.7'
-    propertiesClientVersion='1.2.4'
+    propertiesClientVersion='1.2.5'
     contractClientVersion='1.2.4'
     snsClientVersion='0.2.4'
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6150

## 🛠 Changes

- adds test cases to `ProperyServiceMockTest`
- modifies `PropertiesClientImpl` slightly to increase test-ability

## ✅ Acceptance Validation

These changes increase code coverage from 88.7% to 91.5%

https://sonarqube.cloud.cms.gov/code?id=ab2d-lib-project&branch=AB2D-6150&selected=ab2d-lib-project%3Aab2d-properties-client%2Fsrc%2Fmain%2Fjava%2Fgov%2Fcms%2Fab2d%2Fproperties%2Fclient%2FPropertiesClientImpl.java

<img width="902" alt="image" src="https://github.com/CMSgov/AB2D-Libs/assets/5768468/c8b86955-f948-43f7-bfeb-46c9508e39e0">


## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
