### PR TITLE
[AB2D-6149] increase `ab2d-filters` test coverage

### DIFF
--- a/ab2d-filters/src/test/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerR4Test.java
+++ b/ab2d-filters/src/test/java/gov/cms/ab2d/filter/ExplanationOfBenefitTrimmerR4Test.java
@@ -234,6 +234,12 @@ class ExplanationOfBenefitTrimmerR4Test {
     }
 
     @Test
+    void testNullEOB() {
+        ExplanationOfBenefit eob = (ExplanationOfBenefit) ExplanationOfBenefitTrimmerR4.getBenefit((ExplanationOfBenefit) null);
+        assertNull(eob);
+    }
+
+    @Test
     void extensionCleanupTestCarrier() {
         IBaseResource eob = EOBLoadUtilities.getR4EOBFromFileInClassPath("eobdata/EOB-for-Carrier-R4.json");
         giveStats(eob);

--- a/ab2d-filters/src/test/java/gov/cms/ab2d/filter/FilterTest.java
+++ b/ab2d-filters/src/test/java/gov/cms/ab2d/filter/FilterTest.java
@@ -1,5 +1,6 @@
 package gov.cms.ab2d.filter;
 
+import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.ExplanationOfBenefit;
 import org.hl7.fhir.r4.model.Period;
 import org.junit.jupiter.api.Test;
@@ -19,9 +20,11 @@ class FilterTest {
         SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yyyy HH:mm", Locale.US);
 
         ExplanationOfBenefit eob1 = new ExplanationOfBenefit();
+        IBaseResource eob2 = ExplanationOfBenefitTrimmerSTU3.getBenefit(EOBLoadUtilities.getSTU3EOBFromFileInClassPath("eobdata/EOB-for-Part-D-Claims.json"));
         assertTrue(FilterEob.filter(eob1, null, null, null, true).isEmpty());
         assertTrue(FilterEob.filter(eob1, null, null, new Date(), true).isPresent());
         assertTrue(FilterEob.filter(eob1, null, null, new Date(), false).isEmpty());
+        assertTrue(FilterEob.filter(eob2, null, null, new Date(), false).isEmpty());
 
         Period period = new Period();
         period.setStart(sdf.parse("12/01/2019 00:00"));


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6149

## 🛠 Changes

- Adds some small amount of test coverage for `ExplanationOfBenefitTrimmerR4` and `FilterEob`

## ℹ️ Context for reviewers

I worked on this while https://github.com/CMSgov/AB2D-Libs/pull/388 was under code review. I wasn't sure if that PR would bring `ab2d-filters` up to >90% code coverage, so I decided to keep adding tests.

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
