### PR TITLE
[AB2D-6148] increase `ab2d-fhir` code coverage

### DIFF
--- a/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/Versions.java
+++ b/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/Versions.java
@@ -82,13 +82,8 @@ public class Versions {
                 Class clazz;
                 try {
                     clazz = Class.forName(fullName);
-                } catch (ClassNotFoundException e) {
-                    log.error("Unable to create class " + fullName);
-                    return null;
-                }
-                try {
                     object = clazz.getDeclaredConstructor(null).newInstance();
-                } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                } catch (Exception e) {
                     log.error("Unable to create class " + fullName);
                     return null;
                 }

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
@@ -117,6 +117,16 @@ class PatientIdentifierUtilsTest {
     }
 
     @Test
+    void testRealInput() {
+        Patient patient = new Patient();
+        Identifier identifier = new Identifier();
+        identifier.setSystem("https://bluebutton.cms.gov/resources/variables/bene_id");
+        identifier.setValue("test-1");
+        patient.setIdentifier(List.of(identifier));
+        assertNotNull(IdentifierUtils.getIdentifier(patient.getIdentifier().get(0)));
+    }
+
+    @Test
     void testR4ExtractIds() throws IOException {
         List<String> beneIds = List.of("-19990000001101", "-19990000001102", "-19990000001103");
         List<String> currentMbis = List.of("3S24A00AA00", "4S24A00AA00", "5S24A00AA00");

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
@@ -97,6 +97,19 @@ class PatientIdentifierUtilsTest {
     }
 
     @Test
+    void testEmptyPatients() {
+        Patient patient = new Patient();
+        assertTrue(IdentifierUtils.getIdentifiers(patient).isEmpty());
+    }
+
+    @Test
+    void testEmptyPatientIds() {
+        Patient patient = new Patient();
+        patient.setIdentifier(List.of());
+        assertTrue(IdentifierUtils.getIdentifiers(patient).isEmpty());
+    }
+
+    @Test
     void testR4ExtractIds() throws IOException {
         List<String> beneIds = List.of("-19990000001101", "-19990000001102", "-19990000001103");
         List<String> currentMbis = List.of("3S24A00AA00", "4S24A00AA00", "5S24A00AA00");

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
@@ -127,6 +127,22 @@ class PatientIdentifierUtilsTest {
     }
 
     @Test
+    void testGetBeneId() {
+        PatientIdentifier patientIdentifier = new PatientIdentifier();
+        patientIdentifier.setType(PatientIdentifier.Type.BENE_ID);
+        patientIdentifier.setValue("test-1");
+        assertEquals("test-1", IdentifierUtils.getBeneId(List.of(patientIdentifier)).getValue());
+    }
+
+    @Test
+    void testGetBeneIdWrongType() {
+        PatientIdentifier patientIdentifier = new PatientIdentifier();
+        patientIdentifier.setType(PatientIdentifier.Type.MBI);
+        patientIdentifier.setValue("test-1");
+        assertNull(IdentifierUtils.getBeneId(List.of(patientIdentifier)));
+    }
+
+    @Test
     void testR4ExtractIds() throws IOException {
         List<String> beneIds = List.of("-19990000001101", "-19990000001102", "-19990000001103");
         List<String> currentMbis = List.of("3S24A00AA00", "4S24A00AA00", "5S24A00AA00");

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
@@ -152,6 +152,15 @@ class PatientIdentifierUtilsTest {
     }
 
     @Test
+    void testGetCurrentMbiHistoric() {
+        PatientIdentifier patientIdentifier = new PatientIdentifier();
+        patientIdentifier.setType(PatientIdentifier.Type.MBI);
+        patientIdentifier.setValue("test-1");
+        patientIdentifier.setCurrency(PatientIdentifier.Currency.HISTORIC);
+        assertNull(IdentifierUtils.getCurrentMbi(List.of(patientIdentifier)));
+    }
+
+    @Test
     void testGetCurrentMbiUnknown() {
         PatientIdentifier patientIdentifier = new PatientIdentifier();
         patientIdentifier.setType(PatientIdentifier.Type.MBI);

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
@@ -93,6 +93,11 @@ class PatientIdentifierUtilsTest {
     }
 
     @Test
+    void testNullInput() {
+        assertNull(IdentifierUtils.getIdentifiers(null));
+    }
+
+    @Test
     void testR4ExtractIds() throws IOException {
         List<String> beneIds = List.of("-19990000001101", "-19990000001102", "-19990000001103");
         List<String> currentMbis = List.of("3S24A00AA00", "4S24A00AA00", "5S24A00AA00");

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
@@ -24,6 +24,23 @@ import static gov.cms.ab2d.fhir.IdentifierUtils.getIdentifiers;
 import static org.junit.jupiter.api.Assertions.*;
 
 class PatientIdentifierUtilsTest {
+
+    @Test
+    void testGetTypes() {
+        assertEquals(PatientIdentifier.MBI_ID, PatientIdentifier.Type.MBI.getSystem());
+        assertEquals(PatientIdentifier.Type.MBI, PatientIdentifier.Type.fromSystem(PatientIdentifier.MBI_ID));
+        assertEquals(null, PatientIdentifier.Type.fromSystem("does-not-exist"));
+    }
+
+    @Test
+    void testGetValueAsLong() {
+        PatientIdentifier patientIdentifier = new PatientIdentifier();
+        assertNull(patientIdentifier.getValueAsLong());
+
+        patientIdentifier.setValue("1234");
+        assertEquals(1234, patientIdentifier.getValueAsLong());
+    }
+
     @Test
     void testGetMbis() {
         Patient patient = new Patient();

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
@@ -20,7 +20,6 @@ import static gov.cms.ab2d.fhir.PatientIdentifier.Currency.HISTORIC;
 import static gov.cms.ab2d.fhir.PatientIdentifier.HISTORIC_MBI;
 import static gov.cms.ab2d.fhir.PatientIdentifier.MBI_ID;
 import static gov.cms.ab2d.fhir.IdentifierUtils.CURRENCY_IDENTIFIER;
-import static gov.cms.ab2d.fhir.IdentifierUtils.getIdentifiers;
 import static org.junit.jupiter.api.Assertions.*;
 
 class PatientIdentifierUtilsTest {
@@ -64,7 +63,7 @@ class PatientIdentifierUtilsTest {
         identifier3.addExtension(extension2);
         patient.setIdentifier(List.of(identifier, identifier2, identifier3));
 
-        List<PatientIdentifier> identifiers = gov.cms.ab2d.fhir.IdentifierUtils.getIdentifiers(patient);
+        List<PatientIdentifier> identifiers = IdentifierUtils.getIdentifiers(patient);
         assertEquals("mbi-1", IdentifierUtils.getCurrentMbi(identifiers).getValue());
         Set<PatientIdentifier> historical = IdentifierUtils.getHistoricMbi(identifiers);
         PatientIdentifier h = (PatientIdentifier) historical.toArray()[0];
@@ -76,7 +75,7 @@ class PatientIdentifierUtilsTest {
     void testStu3ExtractIds() throws IOException {
         Bundle resource = (Bundle) extractBundle(FhirVersion.STU3, "data/stu3patients.json");
         for (Bundle.BundleEntryComponent component : resource.getEntry()) {
-            List<PatientIdentifier> ids = getIdentifiers((Patient) component.getResource());
+            List<PatientIdentifier> ids = IdentifierUtils.getIdentifiers((Patient) component.getResource());
             assertEquals(5, ids.size());
             PatientIdentifier benId = IdentifierUtils.getBeneId(ids);
             assertEquals("-19990000001101", benId.getValue());
@@ -101,11 +100,10 @@ class PatientIdentifierUtilsTest {
     void testR4ExtractIds() throws IOException {
         List<String> beneIds = List.of("-19990000001101", "-19990000001102", "-19990000001103");
         List<String> currentMbis = List.of("3S24A00AA00", "4S24A00AA00", "5S24A00AA00");
-        List<String> historicMbis = List.of();
         org.hl7.fhir.r4.model.Bundle resource = (org.hl7.fhir.r4.model.Bundle) extractBundle(FhirVersion.R4, "data/r4patients.json");
         for (org.hl7.fhir.r4.model.Bundle.BundleEntryComponent component : resource.getEntry()) {
             org.hl7.fhir.r4.model.Patient patient = (org.hl7.fhir.r4.model.Patient) component.getResource();
-            List<PatientIdentifier> ids = getIdentifiers(patient);
+            List<PatientIdentifier> ids = IdentifierUtils.getIdentifiers(patient);
             assertEquals(3, ids.size());
 
             PatientIdentifier benId = IdentifierUtils.getBeneId(ids);

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
@@ -6,6 +6,7 @@ import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.dstu3.model.Patient;
 import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -21,6 +22,7 @@ import static gov.cms.ab2d.fhir.PatientIdentifier.HISTORIC_MBI;
 import static gov.cms.ab2d.fhir.PatientIdentifier.MBI_ID;
 import static gov.cms.ab2d.fhir.IdentifierUtils.CURRENCY_IDENTIFIER;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
 class PatientIdentifierUtilsTest {
 
@@ -92,7 +94,7 @@ class PatientIdentifierUtilsTest {
     }
 
     @Test
-    void testNullInput() {
+    void testNullInputs() {
         assertNull(IdentifierUtils.getIdentifiers(null));
     }
 
@@ -107,6 +109,11 @@ class PatientIdentifierUtilsTest {
         Patient patient = new Patient();
         patient.setIdentifier(List.of());
         assertTrue(IdentifierUtils.getIdentifiers(patient).isEmpty());
+    }
+
+    @Test
+    void testMockInput() {
+        assertNull(IdentifierUtils.getIdentifier(mock(ICompositeType.class)));
     }
 
     @Test

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
@@ -143,6 +143,32 @@ class PatientIdentifierUtilsTest {
     }
 
     @Test
+    void testGetCurrentMbiCurrent() {
+        PatientIdentifier patientIdentifier = new PatientIdentifier();
+        patientIdentifier.setType(PatientIdentifier.Type.MBI);
+        patientIdentifier.setValue("test-1");
+        patientIdentifier.setCurrency(PatientIdentifier.Currency.CURRENT);
+        assertEquals("test-1", IdentifierUtils.getCurrentMbi(List.of(patientIdentifier)).getValue());
+    }
+
+    @Test
+    void testGetCurrentMbiUnknown() {
+        PatientIdentifier patientIdentifier = new PatientIdentifier();
+        patientIdentifier.setType(PatientIdentifier.Type.MBI);
+        patientIdentifier.setValue("test-1");
+        patientIdentifier.setCurrency(PatientIdentifier.Currency.UNKNOWN);
+        assertEquals("test-1", IdentifierUtils.getCurrentMbi(List.of(patientIdentifier)).getValue());
+    }
+
+    @Test
+    void testGetCurrentMbiWrongType() {
+        PatientIdentifier patientIdentifier = new PatientIdentifier();
+        patientIdentifier.setType(PatientIdentifier.Type.BENE_ID);
+        patientIdentifier.setValue("test-1");
+        assertNull(IdentifierUtils.getCurrentMbi(List.of(patientIdentifier)));
+    }
+
+    @Test
     void testR4ExtractIds() throws IOException {
         List<String> beneIds = List.of("-19990000001101", "-19990000001102", "-19990000001103");
         List<String> currentMbis = List.of("3S24A00AA00", "4S24A00AA00", "5S24A00AA00");

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/VersionNotSupportedTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/VersionNotSupportedTest.java
@@ -1,0 +1,16 @@
+package gov.cms.ab2d.fhir;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class VersionNotSupportedTest {
+
+  @Test
+  void testConstructor() {
+    assertThrows(RuntimeException.class, () -> {
+      throw new VersionNotSupported("test");
+    });
+  }
+
+}

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/VersionsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/VersionsTest.java
@@ -27,6 +27,14 @@ class VersionsTest {
     }
 
     @Test
+    void executeGetMethodWithBadSetArgs() {
+        ExplanationOfBenefit eob = new ExplanationOfBenefit();
+        Versions.invokeSetMethod(eob, "setPatient", "broken", Reference.class);
+        Object obj = Versions.invokeGetMethod(eob, "getPatient");
+        assertEquals(null, ((Reference) obj).getReference());
+    }
+
+    @Test
     void methodNotAvailableWhenInvokeGet() {
         ExplanationOfBenefit eob = new ExplanationOfBenefit();
         assertThrows(AssertionError.class, () -> {

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/VersionsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/VersionsTest.java
@@ -80,6 +80,9 @@ class VersionsTest {
     void executeInstantiateSimpleEnum() {
         Object obj = Versions.instantiateEnum(R4, "Enumerations", "ResourceType", "PATIENT");
         assertEquals(Enumerations.ResourceType.PATIENT, obj);
+
+        obj = Versions.instantiateEnum(R4, "Enumerations", "FAKE", "PATIENT");
+        assertNull(obj);
     }
 
     @Test

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/VersionsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/VersionsTest.java
@@ -70,6 +70,11 @@ class VersionsTest {
     }
 
     @Test
+    void testInvalidClass() {
+        assertNull(Versions.instantiateClass(STU3, "does-not-exist", "does-not-exist"));
+    }
+
+    @Test
     void testInvalidVersion() {
         assertNull(Versions.getObject(STU3, "Bogus"));
         assertNull(Versions.getObject(STU3, "Bogus", "dumb", String.class));

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
             : System.getenv()['ARTIFACTORY_PASSWORD']
 
     // AB2D libraries
-    fhirVersion='1.2.4'
+    fhirVersion='1.2.5'
     bfdVersion='2.2.0'
     aggregatorVersion='1.3.4'
     filtersVersion='1.9.4'


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6148

## 🛠 Changes

- Modifies the `Versions` class for the purpose of increasing code coverage
- increases code coverage for the `PatientIdentifier` class
- increases code coverage for the `IdentifierUtils` class
- increases code coverage for the `VersionNotSupported` class (its only 1 line)
- increases code coverage for the `Versions` class (same class as above)
- bumps the version since I'm changing the src code

## 🔒 Security Implications

- [ ] This PR adds a new software dependency or dependencies.
- [ ] This PR modifies or invalidates one or more of our security controls.
- [ ] This PR stores or transmits data that was not stored or transmitted before.
- [ ] This PR requires additional review of its security implications for other reasons.

If any security implications apply, add Jason Ashbaugh (GitHub username: StewGoin) as a reviewer and do not merge this PR without his approval.
