### PR TITLE
[AB2D-6148] increase `ab2d-fhir` code coverage

### DIFF
--- a/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/ExtensionUtils.java
+++ b/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/ExtensionUtils.java
@@ -39,11 +39,7 @@ public final class ExtensionUtils {
         if (resource == null || extension == null) {
             return;
         }
-        try {
-            Versions.invokeSetMethod(resource, "addExtension", extension, Class.forName(version.getClassName(EXTENSION_CLASSNAME)));
-        } catch (Exception ex) {
-            log.error("Unable to add Extension");
-        }
+        Versions.invokeSetMethod(resource, "addExtension", extension, version.getClassFromName(EXTENSION_CLASSNAME));
     }
 
     /**
@@ -64,21 +60,12 @@ public final class ExtensionUtils {
 
         Object currencyExtension = Versions.getObject(version, EXTENSION_CLASSNAME);
         Versions.invokeSetMethod(currencyExtension, "setUrl", CURRENCY_IDENTIFIER, String.class);
-        try {
-            Versions.invokeSetMethod(currencyExtension, SET_VALUE_METHOD_NAME, coding, Class.forName(version.getClassName("Type")));
-        } catch (Exception ex) {
-            log.error("Unable to setValue");
-        }
-
+        Versions.invokeSetMethod(currencyExtension, SET_VALUE_METHOD_NAME, coding, version.getClassFromName("Type"));
         Versions.invokeSetMethod(identifier, "setExtension", List.of(currencyExtension), List.class);
 
         Object ext = Versions.getObject(version, EXTENSION_CLASSNAME);
         Versions.invokeSetMethod(ext, "setUrl", ID_EXT, String.class);
-        try {
-            Versions.invokeSetMethod(ext, SET_VALUE_METHOD_NAME, identifier, Class.forName(version.getClassName("Type")));
-        } catch (Exception ex) {
-            log.error("Unable to setValue");
-        }
+        Versions.invokeSetMethod(ext, SET_VALUE_METHOD_NAME, identifier, version.getClassFromName("Type"));
         return (IBase) ext;
     }
 

--- a/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/FhirVersion.java
+++ b/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/FhirVersion.java
@@ -68,6 +68,13 @@ public enum FhirVersion {
         return bfdVersionString;
     }
 
+    public String getClassName(String name) {
+        if (this.classLocation == null) {
+            return null;
+        }
+        return this.classLocation + "." + name;
+    }
+
     public Class<?> getClassFromName(String name) {
         try {
             return Class.forName(getClassName(name));
@@ -75,13 +82,6 @@ public enum FhirVersion {
             log.error(String.format("Unable to create a class from name: %s", name), e);
             return null;
         }
-    }
-
-    public String getClassName(String name) {
-        if (this.classLocation == null) {
-            return null;
-        }
-        return this.classLocation + "." + name;
     }
 
     public Class<? extends IBaseBundle> getBundleClass() {

--- a/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/FhirVersion.java
+++ b/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/FhirVersion.java
@@ -68,6 +68,15 @@ public enum FhirVersion {
         return bfdVersionString;
     }
 
+    public Class<?> getClassFromName(String name) {
+        try {
+            return Class.forName(getClassName(name));
+        } catch (Exception e) {
+            log.error(String.format("Unable to create a class from name: %s", name), e);
+            return null;
+        }
+    }
+
     public String getClassName(String name) {
         if (this.classLocation == null) {
             return null;

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/ExtensionUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/ExtensionUtilsTest.java
@@ -6,6 +6,7 @@ import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Calendar;
 import java.util.Date;
@@ -19,14 +20,14 @@ import static gov.cms.ab2d.fhir.IdentifierUtils.CURRENCY_IDENTIFIER;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ExtensionUtilsTest {
-    @Test
-    void testExtensions() {
-        String mbiIdCurrent = "MBI1";
-        String mbiIdPrevious = "MBI1";
-        org.hl7.fhir.dstu3.model.ExplanationOfBenefit eob = new org.hl7.fhir.dstu3.model.ExplanationOfBenefit();
-        IBase extension = ExtensionUtils.createMbiExtension(mbiIdCurrent, true, STU3);
-        ExtensionUtils.addExtension(eob, extension, STU3);
 
+    @Test
+    void testAddExtension() {
+        String mbiId = "MBI1";
+        org.hl7.fhir.dstu3.model.ExplanationOfBenefit eob = new org.hl7.fhir.dstu3.model.ExplanationOfBenefit();
+        IBase extension = ExtensionUtils.createMbiExtension(mbiId, true, STU3);
+
+        ExtensionUtils.addExtension(eob, extension, STU3);
         List<Extension> extensions = eob.getExtension();
         assertNotNull(extensions);
         assertEquals(1, extensions.size());
@@ -35,13 +36,31 @@ class ExtensionUtilsTest {
         Identifier id = (Identifier) ex.getValue();
         assertNotNull(id);
         assertEquals(MBI_ID, id.getSystem());
-        assertEquals(mbiIdCurrent, id.getValue());
+        assertEquals(mbiId, id.getValue());
         List<Extension> extensions2 = id.getExtension();
         Extension ex2 = extensions2.get(0);
         assertNotNull(extensions2);
         assertEquals(CURRENCY_IDENTIFIER, ex2.getUrl());
         Coding c = (Coding) ex2.getValue();
         assertEquals(CURRENT_MBI, c.getCode());
+    }
+
+    @Test
+    void testAddExtensionInvalidCases() {
+        String mbiId = "MBI1";
+        org.hl7.fhir.dstu3.model.ExplanationOfBenefit eob = new org.hl7.fhir.dstu3.model.ExplanationOfBenefit();
+        IBase extension = ExtensionUtils.createMbiExtension(mbiId, true, STU3);
+
+        assertTrue(eob.getExtension().isEmpty());
+        ExtensionUtils.addExtension(null, extension, STU3);
+        assertTrue(eob.getExtension().isEmpty());
+        ExtensionUtils.addExtension(eob, null, STU3);
+        assertTrue(eob.getExtension().isEmpty());
+        ExtensionUtils.addExtension(null, null, STU3);
+        assertTrue(eob.getExtension().isEmpty());
+
+        ExtensionUtils.addExtension(eob, extension, STU3);
+        assertFalse(eob.getExtension().isEmpty());
     }
 
     @Test

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/ExtensionUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/ExtensionUtilsTest.java
@@ -24,12 +24,14 @@ class ExtensionUtilsTest {
     void testAddExtension() {
         String mbiId = "MBI1";
         org.hl7.fhir.dstu3.model.ExplanationOfBenefit eob = new org.hl7.fhir.dstu3.model.ExplanationOfBenefit();
-        IBase extension = ExtensionUtils.createMbiExtension(mbiId, true, STU3);
-        ExtensionUtils.addExtension(eob, extension, STU3);
+        IBase extension1 = ExtensionUtils.createMbiExtension(mbiId, true, STU3);
+        IBase extension2 = ExtensionUtils.createMbiExtension(mbiId, false, STU3);
+        ExtensionUtils.addExtension(eob, extension1, STU3);
+        ExtensionUtils.addExtension(eob, extension2, STU3);
 
         List<Extension> extensions = eob.getExtension();
         assertNotNull(extensions);
-        assertEquals(1, extensions.size());
+        assertEquals(2, extensions.size());
         Extension ex = extensions.get(0);
         assertEquals(ID_EXT, ex.getUrl());
         Identifier id = (Identifier) ex.getValue();

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/ExtensionUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/ExtensionUtilsTest.java
@@ -26,8 +26,8 @@ class ExtensionUtilsTest {
         String mbiId = "MBI1";
         org.hl7.fhir.dstu3.model.ExplanationOfBenefit eob = new org.hl7.fhir.dstu3.model.ExplanationOfBenefit();
         IBase extension = ExtensionUtils.createMbiExtension(mbiId, true, STU3);
-
         ExtensionUtils.addExtension(eob, extension, STU3);
+g
         List<Extension> extensions = eob.getExtension();
         assertNotNull(extensions);
         assertEquals(1, extensions.size());

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/ExtensionUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/ExtensionUtilsTest.java
@@ -27,7 +27,7 @@ class ExtensionUtilsTest {
         org.hl7.fhir.dstu3.model.ExplanationOfBenefit eob = new org.hl7.fhir.dstu3.model.ExplanationOfBenefit();
         IBase extension = ExtensionUtils.createMbiExtension(mbiId, true, STU3);
         ExtensionUtils.addExtension(eob, extension, STU3);
-g
+
         List<Extension> extensions = eob.getExtension();
         assertNotNull(extensions);
         assertEquals(1, extensions.size());

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/ExtensionUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/ExtensionUtilsTest.java
@@ -6,7 +6,6 @@ import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Calendar;
 import java.util.Date;

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/FhirVersionTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/FhirVersionTest.java
@@ -114,7 +114,7 @@ class FhirVersionTest {
     });
     assertNull(FhirVersion.R4.getClassFromName("doesNotExist"));
     assertDoesNotThrow(() -> {
-      g.getClassFromName("doesNotExist");
+      FhirVersion.STU3.getClassFromName("doesNotExist");
     });
     assertNull(FhirVersion.STU3.getClassFromName("doesNotExist"));
   }

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/FhirVersionTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/FhirVersionTest.java
@@ -113,6 +113,10 @@ class FhirVersionTest {
       FhirVersion.R4.getClassFromName("doesNotExist");
     });
     assertNull(FhirVersion.R4.getClassFromName("doesNotExist"));
+    assertDoesNotThrow(() -> {
+      g.getClassFromName("doesNotExist");
+    });
+    assertNull(FhirVersion.STU3.getClassFromName("doesNotExist"));
   }
 
   @Test

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/FhirVersionTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/FhirVersionTest.java
@@ -3,6 +3,7 @@ package gov.cms.ab2d.fhir;
 import java.time.OffsetDateTime;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -95,6 +96,23 @@ class FhirVersionTest {
     ReflectionTestUtils.setField(FhirVersion.R4, "classLocation", null);
     assertNull(FhirVersion.R4.getClassName("Patient"));
     ReflectionTestUtils.setField(FhirVersion.R4, "classLocation", classLocation);
+  }
+
+  @Test
+  void testGetClassFromName() {
+    assertEquals(
+      org.hl7.fhir.dstu3.model.Patient.class,
+      FhirVersion.STU3.getClassFromName("Patient")
+    );
+    assertEquals(
+      org.hl7.fhir.r4.model.Patient.class,
+      FhirVersion.R4.getClassFromName("Patient")
+    );
+
+    assertDoesNotThrow(() -> {
+      FhirVersion.R4.getClassFromName("doesNotExist");
+    });
+    assertNull(FhirVersion.R4.getClassFromName("doesNotExist"));
   }
 
   @Test

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
             : System.getenv()['ARTIFACTORY_PASSWORD']
 
     // AB2D libraries
-    fhirVersion='1.2.5'
+    fhirVersion='1.2.6'
     bfdVersion='2.2.0'
     aggregatorVersion='1.3.4'
     filtersVersion='1.9.4'


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6148

## 🛠 Changes

- Adds a `FhirVersion.getClassFromName` function, which is patterned off of the other methods in that file. It is a simple class that calls `Class.forName(...)` and logs all exceptions.
- Changes `ExtensionUtils` to use `FhirVersion.getClassFromName`. This means that `ExtensionUtils` can get rid of a few `try ... except` blocks that were functionally dead code. Those lines were dead code because they were calling `Class.forName(...)` on static strings... so they were never going to raise an exception. Hence, it was impossible to test them in their previous form.
- Adds tests for the above.

## ℹ️ Context

The goal of this PR is to increase test coverage for our code. At present `ExtensionUtils` has the lowest test coverage of all the files in this folder. Unfortunately, none of the code is "easy" to test, so I'm having to resort to code changes to get test coverage any higher.

<img width="1446" alt="image" src="https://github.com/CMSgov/AB2D-Libs/assets/5768468/173195e5-c522-4418-bd00-a8fb7c266227">

The code I added has 100% test coverage 😎 . Additionally, `FhirVersion` and `ExtensionUtils` now both have 100% test coverage as well.

<img width="1469" alt="image" src="https://github.com/CMSgov/AB2D-Libs/assets/5768468/6c44864d-b183-483d-b0e3-c8bed2ef09d9">
