### PR TITLE
[AB2D-6101] Address Critical Code Smell - Reduce cognitive method compleixty

### DIFF
--- a/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/IdentifierUtils.java
+++ b/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/IdentifierUtils.java
@@ -211,25 +211,22 @@ public final class IdentifierUtils {
         Object type = Versions.invokeGetMethod(identifier, "getType");
         List<Coding> vals = (List) Versions.invokeGetMethod(type, "getCoding");
 
-        if (!checkTypeAndCodingExists(type, vals)) {
+        if (checkTypeAndCodingNotExists(type, vals)) {
             return PatientIdentifier.Currency.UNKNOWN;
         }
 
         Object val = vals.get(0);
         String codeSystem = (String) Versions.invokeGetMethod(val, GET_SYSTEM);
         String codeValue = (String) Versions.invokeGetMethod(val, GET_CODE);
-        if (!checkCodingIsValid(codeSystem, codeValue)) {
-            return PatientIdentifier.Currency.UNKNOWN;
-        }
 
-        List extensions = (List) Versions.invokeGetMethod(val, "getExtension");
-        if (extensions == null || extensions.isEmpty()) {
+        List<IBaseExtension> extensions = (List) Versions.invokeGetMethod(val, "getExtension");
+        if (checkCodingIsNotValid(codeSystem, codeValue) || checkExtensionsNotExists(extensions)) {
             return PatientIdentifier.Currency.UNKNOWN;
         }
 
         Object extension = extensions.get(0);
         String url = (String) Versions.invokeGetMethod(extension, "getUrl");
-        if (!checkCurrencyUrlIsValid(url)) {
+        if (checkCurrencyUrlIsNotValid(url)) {
             return PatientIdentifier.Currency.UNKNOWN;
         }
         
@@ -247,16 +244,20 @@ public final class IdentifierUtils {
         return PatientIdentifier.Currency.UNKNOWN;
     }
 
-    public static boolean checkTypeAndCodingExists(Object type, List<Coding> vals) {
-        return (type != null && vals != null && !vals.isEmpty());
+    public static boolean checkTypeAndCodingNotExists(Object type, List<Coding> vals) {
+        return (type == null || vals == null || vals.isEmpty());
     }
 
-    public static boolean checkCodingIsValid(String codeSystem, String codeValue) {
-        return ((codeSystem != null && codeSystem.equalsIgnoreCase(MBI_ID_R4)) && ("MB".equalsIgnoreCase(codeValue) || "MC".equalsIgnoreCase(codeValue)));
+    public static boolean checkCodingIsNotValid(String codeSystem, String codeValue) {
+        return (codeSystem == null || !codeSystem.equalsIgnoreCase(MBI_ID_R4)) || (!codeValue.equalsIgnoreCase("MB") && !codeValue.equalsIgnoreCase("MC"));
     }
 
-    public static boolean checkCurrencyUrlIsValid(String url) {
-        return (url != null && url.equalsIgnoreCase(CURRENCY_IDENTIFIER));
+    public static boolean checkExtensionsNotExists(List<IBaseExtension> extensions) {
+        return (extensions == null || extensions.isEmpty());
+    }
+
+    public static boolean checkCurrencyUrlIsNotValid(String url) {
+        return (url == null || !url.equalsIgnoreCase(CURRENCY_IDENTIFIER));
     }
 
     /**

--- a/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/IdentifierUtils.java
+++ b/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/IdentifierUtils.java
@@ -210,11 +210,11 @@ public final class IdentifierUtils {
         Object type = Versions.invokeGetMethod(identifier, "getType");
         List vals = (List) Versions.invokeGetMethod(type, "getCoding");
 
-        if (checkTypeAndValsExists(type, vals)) {
+        if (!checkTypeAndCodingExists(type, vals)) {
             return PatientIdentifier.Currency.UNKNOWN;
         }
 
-        if (!checkCodeSystemAndValueIsValid(vals)) {
+        if (!checkCodingIsValid(vals)) {
             return PatientIdentifier.Currency.UNKNOWN;
         }
 
@@ -240,17 +240,17 @@ public final class IdentifierUtils {
         return PatientIdentifier.Currency.UNKNOWN;
     }
 
-    private static boolean checkTypeAndValsExists(Object type, List vals) {
+    public static boolean checkTypeAndCodingExists(Object type, List vals) {
         if (type == null) {
-            return true;
+            return false;
         }
         if (vals == null || vals.isEmpty()) {
-            return true;
+            return false;
         }
-        return false;
+        return true;
     }
 
-    private static boolean checkCodeSystemAndValueIsValid(List vals) {
+    public static boolean checkCodingIsValid(List vals) {
         if (vals == null || vals.isEmpty()) {
             return false;
         }
@@ -264,7 +264,7 @@ public final class IdentifierUtils {
         return false;
     }
 
-    private static boolean checkExtensionsHasValidUrl(List extensions) {
+    public static boolean checkExtensionsHasValidUrl(List extensions) {
         if (extensions != null && !extensions.isEmpty()) {
             Object extension = extensions.get(0);
             String url = (String) Versions.invokeGetMethod(extension, "getUrl");

--- a/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/IdentifierUtils.java
+++ b/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/IdentifierUtils.java
@@ -214,14 +214,14 @@ public final class IdentifierUtils {
             return PatientIdentifier.Currency.UNKNOWN;
         }
 
-        if (!checkCodeSystemAndValueIsValid()) {
+        if (!checkCodeSystemAndValueIsValid(vals)) {
             return PatientIdentifier.Currency.UNKNOWN;
         }
 
         Object val = vals.get(0);
         List extensions = (List) Versions.invokeGetMethod(val, "getExtension");
         
-        if (!checkExtensionsHasValidUrl()) {
+        if (!checkExtensionsHasValidUrl(extensions)) {
             return PatientIdentifier.Currency.UNKNOWN;
         }
         

--- a/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/IdentifierUtils.java
+++ b/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/IdentifierUtils.java
@@ -208,37 +208,71 @@ public final class IdentifierUtils {
 
     private static PatientIdentifier.Currency getCurrencyFromTypeCodingExtension(ICompositeType identifier) {
         Object type = Versions.invokeGetMethod(identifier, "getType");
-        if (type == null) {
-            return PatientIdentifier.Currency.UNKNOWN;
-        }
         List vals = (List) Versions.invokeGetMethod(type, "getCoding");
-        if (vals == null || vals.isEmpty()) {
+
+        if (checkTypeAndValsExists(type, vals)) {
             return PatientIdentifier.Currency.UNKNOWN;
         }
+
+        if (!checkCodeSystemAndValueIsValid()) {
+            return PatientIdentifier.Currency.UNKNOWN;
+        }
+
+        Object val = vals.get(0);
+        List extensions = (List) Versions.invokeGetMethod(val, "getExtension");
+        
+        if (!checkExtensionsHasValidUrl()) {
+            return PatientIdentifier.Currency.UNKNOWN;
+        }
+        
+        Object extension = extensions.get(0);
+        Object currValue = Versions.invokeGetMethod(extension, GET_VALUE);
+        String extValueSystem = (String) Versions.invokeGetMethod(currValue, GET_SYSTEM);
+        if (CURRENCY_IDENTIFIER.equalsIgnoreCase(extValueSystem)) {
+            String currValueCode = (String) Versions.invokeGetMethod(currValue, GET_CODE);
+            if (CURRENT_MBI.equalsIgnoreCase(currValueCode)) {
+                return PatientIdentifier.Currency.CURRENT;
+            }
+            if (HISTORIC_MBI.equalsIgnoreCase(currValueCode)) {
+                return PatientIdentifier.Currency.HISTORIC;
+            }
+        }
+        return PatientIdentifier.Currency.UNKNOWN;
+    }
+
+    private static boolean checkTypeAndValsExists(Object type, List vals) {
+        if (type == null) {
+            return true;
+        }
+        if (vals == null || vals.isEmpty()) {
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean checkCodeSystemAndValueIsValid(List vals) {
+        if (vals == null || vals.isEmpty()) {
+            return false;
+        }
+
         Object val = vals.get(0);
         String codeSystem = (String) Versions.invokeGetMethod(val, GET_SYSTEM);
         String codeValue = (String) Versions.invokeGetMethod(val, GET_CODE);
         if (codeSystem != null && codeSystem.equalsIgnoreCase(MBI_ID_R4) && ("MB".equalsIgnoreCase(codeValue) || "MC".equalsIgnoreCase(codeValue))) {
-            List extensions = (List) Versions.invokeGetMethod(val, "getExtension");
-            if (extensions != null && extensions.size() > 0) {
-                Object extension = extensions.get(0);
-                String url = (String) Versions.invokeGetMethod(extension, "getUrl");
-                if (url != null && url.equalsIgnoreCase(CURRENCY_IDENTIFIER)) {
-                    Object currValue = Versions.invokeGetMethod(extension, GET_VALUE);
-                    String extValueSystem = (String) Versions.invokeGetMethod(currValue, GET_SYSTEM);
-                    if (CURRENCY_IDENTIFIER.equalsIgnoreCase(extValueSystem)) {
-                        String currValueCode = (String) Versions.invokeGetMethod(currValue, GET_CODE);
-                        if (CURRENT_MBI.equalsIgnoreCase(currValueCode)) {
-                            return PatientIdentifier.Currency.CURRENT;
-                        }
-                        if (HISTORIC_MBI.equalsIgnoreCase(currValueCode)) {
-                            return PatientIdentifier.Currency.HISTORIC;
-                        }
-                    }
-                }
+            return true;
+        }
+        return false;
+    }
+
+    private static boolean checkExtensionsHasValidUrl(List extensions) {
+        if (extensions != null && !extensions.isEmpty()) {
+            Object extension = extensions.get(0);
+            String url = (String) Versions.invokeGetMethod(extension, "getUrl");
+            if (url != null && url.equalsIgnoreCase(CURRENCY_IDENTIFIER)) {
+                return true;
             }
         }
-        return PatientIdentifier.Currency.UNKNOWN;
+        return false;
     }
 
     /**

--- a/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/IdentifierUtils.java
+++ b/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/IdentifierUtils.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.hl7.fhir.instance.model.api.IDomainResource;
+import org.hl7.fhir.dstu3.model.Coding;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -208,7 +209,7 @@ public final class IdentifierUtils {
 
     public static PatientIdentifier.Currency getCurrencyFromTypeCodingExtension(ICompositeType identifier) {
         Object type = Versions.invokeGetMethod(identifier, "getType");
-        List vals = (List) Versions.invokeGetMethod(type, "getCoding");
+        List<Coding> vals = (List) Versions.invokeGetMethod(type, "getCoding");
 
         if (!checkTypeAndCodingExists(type, vals)) {
             return PatientIdentifier.Currency.UNKNOWN;
@@ -246,7 +247,7 @@ public final class IdentifierUtils {
         return PatientIdentifier.Currency.UNKNOWN;
     }
 
-    public static boolean checkTypeAndCodingExists(Object type, List vals) {
+    public static boolean checkTypeAndCodingExists(Object type, List<Coding> vals) {
         return (type != null && vals != null && !vals.isEmpty());
     }
 

--- a/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/IdentifierUtils.java
+++ b/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/IdentifierUtils.java
@@ -214,18 +214,24 @@ public final class IdentifierUtils {
             return PatientIdentifier.Currency.UNKNOWN;
         }
 
-        if (!checkCodingIsValid(vals)) {
+        Object val = vals.get(0);
+        String codeSystem = (String) Versions.invokeGetMethod(val, GET_SYSTEM);
+        String codeValue = (String) Versions.invokeGetMethod(val, GET_CODE);
+        if (!checkCodingIsValid(codeSystem, codeValue)) {
             return PatientIdentifier.Currency.UNKNOWN;
         }
 
-        Object val = vals.get(0);
         List extensions = (List) Versions.invokeGetMethod(val, "getExtension");
-        
-        if (!checkExtensionsHasValidUrl(extensions)) {
+        if (extensions == null || extensions.isEmpty()) {
+            return PatientIdentifier.Currency.UNKNOWN;
+        }
+
+        Object extension = extensions.get(0);
+        String url = (String) Versions.invokeGetMethod(extension, "getUrl");
+        if (!checkCurrencyUrlIsValid(url)) {
             return PatientIdentifier.Currency.UNKNOWN;
         }
         
-        Object extension = extensions.get(0);
         Object currValue = Versions.invokeGetMethod(extension, GET_VALUE);
         String extValueSystem = (String) Versions.invokeGetMethod(currValue, GET_SYSTEM);
         if (CURRENCY_IDENTIFIER.equalsIgnoreCase(extValueSystem)) {
@@ -241,38 +247,15 @@ public final class IdentifierUtils {
     }
 
     public static boolean checkTypeAndCodingExists(Object type, List vals) {
-        if (type == null) {
-            return false;
-        }
-        if (vals == null || vals.isEmpty()) {
-            return false;
-        }
-        return true;
+        return (type != null && vals != null && !vals.isEmpty());
     }
 
-    public static boolean checkCodingIsValid(List vals) {
-        if (vals == null || vals.isEmpty()) {
-            return false;
-        }
-
-        Object val = vals.get(0);
-        String codeSystem = (String) Versions.invokeGetMethod(val, GET_SYSTEM);
-        String codeValue = (String) Versions.invokeGetMethod(val, GET_CODE);
-        if (codeSystem != null && codeSystem.equalsIgnoreCase(MBI_ID_R4) && ("MB".equalsIgnoreCase(codeValue) || "MC".equalsIgnoreCase(codeValue))) {
-            return true;
-        }
-        return false;
+    public static boolean checkCodingIsValid(String codeSystem, String codeValue) {
+        return ((codeSystem != null && codeSystem.equalsIgnoreCase(MBI_ID_R4)) && ("MB".equalsIgnoreCase(codeValue) || "MC".equalsIgnoreCase(codeValue)));
     }
 
-    public static boolean checkExtensionsHasValidUrl(List extensions) {
-        if (extensions != null && !extensions.isEmpty()) {
-            Object extension = extensions.get(0);
-            String url = (String) Versions.invokeGetMethod(extension, "getUrl");
-            if (url != null && url.equalsIgnoreCase(CURRENCY_IDENTIFIER)) {
-                return true;
-            }
-        }
-        return false;
+    public static boolean checkCurrencyUrlIsValid(String url) {
+        return (url != null && url.equalsIgnoreCase(CURRENCY_IDENTIFIER));
     }
 
     /**

--- a/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/IdentifierUtils.java
+++ b/ab2d-fhir/src/main/java/gov/cms/ab2d/fhir/IdentifierUtils.java
@@ -206,7 +206,7 @@ public final class IdentifierUtils {
         return getCurrencyFromTypeCodingExtension(identifier);
     }
 
-    private static PatientIdentifier.Currency getCurrencyFromTypeCodingExtension(ICompositeType identifier) {
+    public static PatientIdentifier.Currency getCurrencyFromTypeCodingExtension(ICompositeType identifier) {
         Object type = Versions.invokeGetMethod(identifier, "getType");
         List vals = (List) Versions.invokeGetMethod(type, "getCoding");
 

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
@@ -314,7 +314,7 @@ class PatientIdentifierUtilsTest {
 
     @Test
     void testReturnsTrueIfExtensionsNotExists() {
-        assertTrue(IdentifierUtils.checkExtensionsNotExists(new ArrayList()<>));
+        assertTrue(IdentifierUtils.checkExtensionsNotExists(new ArrayList<>()));
     }
 
     @Test

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
@@ -187,6 +187,177 @@ class PatientIdentifierUtilsTest {
     }
 
     @Test
+    void testGetCurrencyFromTypeCodingExtensionReturnsCurrent() {
+        Patient patient = new Patient();
+        Identifier identifier = new Identifier();
+        identifier.setSystem(MBI_ID);
+
+        Coding coding = new Coding();
+        coding.setSystem(MBI_ID_R4);
+        coding.setCode("MB");
+        identifier.getType().addCoding(coding);
+
+        identifier.setValue("mbi-1");
+        
+        Extension extension = new Extension();
+        extension.setUrl(CURRENCY_IDENTIFIER);
+        Coding extCoding = new Coding();
+        extCoding.setSystem(CURRENCY_IDENTIFIER);
+        extCoding.setCode(CURRENT_MBI);
+        extension.setValue(extCoding);
+        identifier.getType().getCoding().get(0).addExtension(extension);
+
+        patient.setIdentifier(List.of(identifier));
+
+        assertEquals(PatientIdentifier.Currency.CURRENT, IdentifierUtils.getCurrencyFromTypeCodingExtension(patient.getIdentifier().get(0)));
+    }
+
+    @Test
+    void testGetCurrencyFromTypeCodingExtensionReturnsHistoric() {
+        Patient patient = new Patient();
+        Identifier identifier = new Identifier();
+        identifier.setSystem(MBI_ID);
+
+        Coding coding = new Coding();
+        coding.setSystem(MBI_ID_R4);
+        coding.setCode("MB");
+        identifier.getType().addCoding(coding);
+
+        identifier.setValue("mbi-1");
+        
+        Extension extension = new Extension();
+        extension.setUrl(CURRENCY_IDENTIFIER);
+        Coding extCoding = new Coding();
+        extCoding.setSystem(CURRENCY_IDENTIFIER);
+        extCoding.setCode(HISTORIC_MBI);
+        extension.setValue(extCoding);
+        identifier.getType().getCoding().get(0).addExtension(extension);
+
+        patient.setIdentifier(List.of(identifier));
+
+        assertEquals(PatientIdentifier.Currency.HISTORIC, IdentifierUtils.getCurrencyFromTypeCodingExtension(patient.getIdentifier().get(0)));
+    }
+
+    @Test
+    void testGetCurrencyFromTypeCodingExtensionReturnsUnknown() {
+        Patient patient = new Patient();
+        Identifier identifier = new Identifier();
+        identifier.setSystem(MBI_ID);
+
+        Coding coding = new Coding();
+        coding.setSystem(MBI_ID_R4);
+        coding.setCode("MB");
+        identifier.getType().addCoding(coding);
+
+        identifier.setValue("mbi-1");
+        
+        Extension extension = new Extension();
+        extension.setUrl(CURRENCY_IDENTIFIER);
+        Coding extCoding = new Coding();
+        extCoding.setSystem(CURRENCY_IDENTIFIER);
+        extCoding.setCode("unknown");
+        extension.setValue(extCoding);
+        identifier.getType().getCoding().get(0).addExtension(extension);
+
+        patient.setIdentifier(List.of(identifier));
+
+        assertEquals(PatientIdentifier.Currency.UNKNOWN, IdentifierUtils.getCurrencyFromTypeCodingExtension(patient.getIdentifier().get(0)));
+    }
+
+    @Test
+    void testGetCurrencyFromTypeCodingExtensionReturnsUnknownWhenCodingEmpty() {
+        Patient patient = new Patient();
+        Identifier identifier = new Identifier();
+        identifier.setSystem(MBI_ID);
+
+        patient.setIdentifier(List.of(identifier));
+
+        assertEquals(PatientIdentifier.Currency.UNKNOWN, IdentifierUtils.getCurrencyFromTypeCodingExtension(patient.getIdentifier().get(0)));
+    }
+
+    @Test
+    void testGetCurrencyFromTypeCodingExtensionReturnsUnknownWhenCodingInvalid() {
+        Patient patient = new Patient();
+        Identifier identifier = new Identifier();
+        identifier.setSystem(MBI_ID);
+
+        Coding coding = new Coding();
+        coding.setSystem("invalid_system");
+        coding.setCode("MB");
+        identifier.getType().addCoding(coding);
+
+        identifier.setValue("mbi-1");
+        
+        Extension extension = new Extension();
+        extension.setUrl(CURRENCY_IDENTIFIER);
+        Coding extCoding = new Coding();
+        extCoding.setSystem(CURRENCY_IDENTIFIER);
+        extCoding.setCode(CURRENT_MBI);
+        extension.setValue(extCoding);
+        identifier.getType().getCoding().get(0).addExtension(extension);
+
+        patient.setIdentifier(List.of(identifier));
+
+        assertEquals(PatientIdentifier.Currency.UNKNOWN, IdentifierUtils.getCurrencyFromTypeCodingExtension(patient.getIdentifier().get(0)));
+
+        coding.setSystem(MBI_ID_R4);
+        coding.setCode("invalid_code");
+        assertEquals(PatientIdentifier.Currency.UNKNOWN, IdentifierUtils.getCurrencyFromTypeCodingExtension(patient.getIdentifier().get(0)));
+    }
+
+    @Test
+    void testGetCurrencyFromTypeCodingExtensionReturnsUnknownWhenUrlNull() {
+        Patient patient = new Patient();
+        Identifier identifier = new Identifier();
+        identifier.setSystem(MBI_ID);
+
+        Coding coding = new Coding();
+        coding.setSystem(MBI_ID_R4);
+        coding.setCode("MB");
+        identifier.getType().addCoding(coding);
+
+        identifier.setValue("mbi-1");
+        
+        Extension extension = new Extension();
+        extension.setUrl(null);
+        Coding extCoding = new Coding();
+        extCoding.setSystem(CURRENCY_IDENTIFIER);
+        extCoding.setCode(CURRENT_MBI);
+        extension.setValue(extCoding);
+        identifier.getType().getCoding().get(0).addExtension(extension);
+
+        patient.setIdentifier(List.of(identifier));
+
+        assertEquals(PatientIdentifier.Currency.UNKNOWN, IdentifierUtils.getCurrencyFromTypeCodingExtension(patient.getIdentifier().get(0)));
+    }
+
+    @Test
+    void testGetCurrencyFromTypeCodingExtensionReturnsUnknownWhenUrlInvalid() {
+        Patient patient = new Patient();
+        Identifier identifier = new Identifier();
+        identifier.setSystem(MBI_ID);
+
+        Coding coding = new Coding();
+        coding.setSystem(MBI_ID_R4);
+        coding.setCode("MB");
+        identifier.getType().addCoding(coding);
+
+        identifier.setValue("mbi-1");
+        
+        Extension extension = new Extension();
+        extension.setUrl("invalid_url");
+        Coding extCoding = new Coding();
+        extCoding.setSystem(CURRENCY_IDENTIFIER);
+        extCoding.setCode(CURRENT_MBI);
+        extension.setValue(extCoding);
+        identifier.getType().getCoding().get(0).addExtension(extension);
+
+        patient.setIdentifier(List.of(identifier));
+
+        assertEquals(PatientIdentifier.Currency.UNKNOWN, IdentifierUtils.getCurrencyFromTypeCodingExtension(patient.getIdentifier().get(0)));
+    }
+
+    @Test
     void testReturnsFalseIfCodingNotExist() {
         PatientIdentifier patientIdentifier = new PatientIdentifier();
         patientIdentifier.setType(PatientIdentifier.Type.MBI);
@@ -200,8 +371,8 @@ class PatientIdentifierUtilsTest {
 
     @Test
     void testReturnsFalseIfCodingInvalid() {
-        String codeSystem = "INVALID";
-        String codeValue = "INVALID";
+        String codeSystem = "invalid_system";
+        String codeValue = "invalid_value";
         assertFalse(IdentifierUtils.checkCodingIsValid(codeSystem, codeValue));
     }
 
@@ -222,7 +393,7 @@ class PatientIdentifierUtilsTest {
 
     @Test
     void testReturnsFalseIfURLInvalid() {
-        String url = "INVALID";
+        String url = "invalid_url";
         assertFalse(IdentifierUtils.checkCurrencyUrlIsValid(url));
     }
 

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
@@ -190,171 +190,101 @@ class PatientIdentifierUtilsTest {
 
     @Test
     void testGetCurrencyFromTypeCodingExtensionReturnsCurrent() {
-        Patient patient = new Patient();
-        Identifier identifier = new Identifier();
-        identifier.setSystem(MBI_ID);
+        Coding coding = setupCodingForTestingCurrencyTypeCode(MBI_ID_R4, "MB");
 
-        Coding coding = new Coding();
-        coding.setSystem(MBI_ID_R4);
-        coding.setCode("MB");
-        identifier.getType().addCoding(coding);
+        Coding extCoding = setupCodingForTestingCurrencyTypeCode(CURRENCY_IDENTIFIER, CURRENT_MBI);
+        Extension extension = setupExtensionForTestingCurrencyTypeCode(CURRENCY_IDENTIFIER, extCoding);
 
-        identifier.setValue("mbi-1");
-        
-        Extension extension = new Extension();
-        extension.setUrl(CURRENCY_IDENTIFIER);
-        Coding extCoding = new Coding();
-        extCoding.setSystem(CURRENCY_IDENTIFIER);
-        extCoding.setCode(CURRENT_MBI);
-        extension.setValue(extCoding);
-        identifier.getType().getCoding().get(0).addExtension(extension);
-
-        patient.setIdentifier(List.of(identifier));
+        Identifier identifier = setupIdentifierForTestingCurrencyTypeCode(coding, extension);
+        Patient patient = setupPatientForTestingCurrencyTypeCode(identifier);
 
         assertEquals(PatientIdentifier.Currency.CURRENT, IdentifierUtils.getCurrencyFromTypeCodingExtension(patient.getIdentifier().get(0)));
     }
 
     @Test
     void testGetCurrencyFromTypeCodingExtensionReturnsHistoric() {
-        Patient patient = new Patient();
-        Identifier identifier = new Identifier();
-        identifier.setSystem(MBI_ID);
+        Coding coding = setupCodingForTestingCurrencyTypeCode(MBI_ID_R4, "MB");
 
-        Coding coding = new Coding();
-        coding.setSystem(MBI_ID_R4);
-        coding.setCode("MB");
-        identifier.getType().addCoding(coding);
+        Coding extCoding = setupCodingForTestingCurrencyTypeCode(CURRENCY_IDENTIFIER, HISTORIC_MBI);
+        Extension extension = setupExtensionForTestingCurrencyTypeCode(CURRENCY_IDENTIFIER, extCoding);
 
-        identifier.setValue("mbi-1");
-        
-        Extension extension = new Extension();
-        extension.setUrl(CURRENCY_IDENTIFIER);
-        Coding extCoding = new Coding();
-        extCoding.setSystem(CURRENCY_IDENTIFIER);
-        extCoding.setCode(HISTORIC_MBI);
-        extension.setValue(extCoding);
-        identifier.getType().getCoding().get(0).addExtension(extension);
-
-        patient.setIdentifier(List.of(identifier));
+        Identifier identifier = setupIdentifierForTestingCurrencyTypeCode(coding, extension);
+        Patient patient = setupPatientForTestingCurrencyTypeCode(identifier);
 
         assertEquals(PatientIdentifier.Currency.HISTORIC, IdentifierUtils.getCurrencyFromTypeCodingExtension(patient.getIdentifier().get(0)));
     }
 
     @Test
     void testGetCurrencyFromTypeCodingExtensionReturnsUnknown() {
-        Patient patient = new Patient();
-        Identifier identifier = new Identifier();
-        identifier.setSystem(MBI_ID);
+        Coding coding = setupCodingForTestingCurrencyTypeCode(MBI_ID_R4, "MB");
 
-        Coding coding = new Coding();
-        coding.setSystem(MBI_ID_R4);
-        coding.setCode("MB");
-        identifier.getType().addCoding(coding);
+        Coding extCoding = setupCodingForTestingCurrencyTypeCode(CURRENCY_IDENTIFIER, "unknown");
+        Extension extension = setupExtensionForTestingCurrencyTypeCode(CURRENCY_IDENTIFIER, extCoding);
 
-        identifier.setValue("mbi-1");
-        
-        Extension extension = new Extension();
-        extension.setUrl(CURRENCY_IDENTIFIER);
-        Coding extCoding = new Coding();
-        extCoding.setSystem(CURRENCY_IDENTIFIER);
-        extCoding.setCode("unknown");
-        extension.setValue(extCoding);
-        identifier.getType().getCoding().get(0).addExtension(extension);
-
-        patient.setIdentifier(List.of(identifier));
+        Identifier identifier = setupIdentifierForTestingCurrencyTypeCode(coding, extension);
+        Patient patient = setupPatientForTestingCurrencyTypeCode(identifier);
 
         assertEquals(PatientIdentifier.Currency.UNKNOWN, IdentifierUtils.getCurrencyFromTypeCodingExtension(patient.getIdentifier().get(0)));
     }
 
     @Test
     void testGetCurrencyFromTypeCodingExtensionReturnsUnknownWhenCodingEmpty() {
-        Patient patient = new Patient();
-        Identifier identifier = new Identifier();
-        identifier.setSystem(MBI_ID);
-
-        patient.setIdentifier(List.of(identifier));
+        Identifier identifier = setupIdentifierForTestingCurrencyTypeCode(null, null);
+        Patient patient = setupPatientForTestingCurrencyTypeCode(identifier);
 
         assertEquals(PatientIdentifier.Currency.UNKNOWN, IdentifierUtils.getCurrencyFromTypeCodingExtension(patient.getIdentifier().get(0)));
     }
 
     @Test
-    void testGetCurrencyFromTypeCodingExtensionReturnsUnknownWhenCodingInvalid() {
-        Patient patient = new Patient();
-        Identifier identifier = new Identifier();
-        identifier.setSystem(MBI_ID);
-
-        Coding coding = new Coding();
-        coding.setSystem("invalid_system");
-        coding.setCode("MB");
-        identifier.getType().addCoding(coding);
-
-        identifier.setValue("mbi-1");
+    void testGetCurrencyFromTypeCodingExtensionReturnsUnknownWhenCodingSystemInvalid() {
+        Coding coding = setupCodingForTestingCurrencyTypeCode("invalid_system", "MB");
         
-        Extension extension = new Extension();
-        extension.setUrl(CURRENCY_IDENTIFIER);
-        Coding extCoding = new Coding();
-        extCoding.setSystem(CURRENCY_IDENTIFIER);
-        extCoding.setCode(CURRENT_MBI);
-        extension.setValue(extCoding);
-        identifier.getType().getCoding().get(0).addExtension(extension);
+        Coding extCoding = setupCodingForTestingCurrencyTypeCode(CURRENCY_IDENTIFIER, CURRENT_MBI);
+        Extension extension = setupExtensionForTestingCurrencyTypeCode(CURRENCY_IDENTIFIER, extCoding);
 
-        patient.setIdentifier(List.of(identifier));
+        Identifier identifier = setupIdentifierForTestingCurrencyTypeCode(coding, extension);
+        Patient patient = setupPatientForTestingCurrencyTypeCode(identifier);
 
         assertEquals(PatientIdentifier.Currency.UNKNOWN, IdentifierUtils.getCurrencyFromTypeCodingExtension(patient.getIdentifier().get(0)));
 
-        coding.setSystem(MBI_ID_R4);
-        coding.setCode("invalid_code");
+    }
+
+    @Test
+    void testGetCurrencyFromTypeCodingExtensionReturnsUnknownWhenCodingCodeInvalid() {
+        Coding coding = setupCodingForTestingCurrencyTypeCode(MBI_ID_R4, "invalid_code");
+        
+        Coding extCoding = setupCodingForTestingCurrencyTypeCode(CURRENCY_IDENTIFIER, CURRENT_MBI);
+        Extension extension = setupExtensionForTestingCurrencyTypeCode(CURRENCY_IDENTIFIER, extCoding);
+
+        Identifier identifier = setupIdentifierForTestingCurrencyTypeCode(coding, extension);
+        Patient patient = setupPatientForTestingCurrencyTypeCode(identifier);
+
         assertEquals(PatientIdentifier.Currency.UNKNOWN, IdentifierUtils.getCurrencyFromTypeCodingExtension(patient.getIdentifier().get(0)));
+
     }
 
     @Test
     void testGetCurrencyFromTypeCodingExtensionReturnsUnknownWhenUrlNull() {
-        Patient patient = new Patient();
-        Identifier identifier = new Identifier();
-        identifier.setSystem(MBI_ID);
-
-        Coding coding = new Coding();
-        coding.setSystem(MBI_ID_R4);
-        coding.setCode("MB");
-        identifier.getType().addCoding(coding);
-
-        identifier.setValue("mbi-1");
+        Coding coding = setupCodingForTestingCurrencyTypeCode(MBI_ID_R4, "MB");
         
-        Extension extension = new Extension();
-        extension.setUrl(null);
-        Coding extCoding = new Coding();
-        extCoding.setSystem(CURRENCY_IDENTIFIER);
-        extCoding.setCode(CURRENT_MBI);
-        extension.setValue(extCoding);
-        identifier.getType().getCoding().get(0).addExtension(extension);
+        Coding extCoding = setupCodingForTestingCurrencyTypeCode(CURRENCY_IDENTIFIER, CURRENT_MBI);
+        Extension extension = setupExtensionForTestingCurrencyTypeCode(null, extCoding);
 
-        patient.setIdentifier(List.of(identifier));
+        Identifier identifier = setupIdentifierForTestingCurrencyTypeCode(coding, extension);
+        Patient patient = setupPatientForTestingCurrencyTypeCode(identifier);
 
         assertEquals(PatientIdentifier.Currency.UNKNOWN, IdentifierUtils.getCurrencyFromTypeCodingExtension(patient.getIdentifier().get(0)));
     }
 
     @Test
     void testGetCurrencyFromTypeCodingExtensionReturnsUnknownWhenUrlInvalid() {
-        Patient patient = new Patient();
-        Identifier identifier = new Identifier();
-        identifier.setSystem(MBI_ID);
-
-        Coding coding = new Coding();
-        coding.setSystem(MBI_ID_R4);
-        coding.setCode("MB");
-        identifier.getType().addCoding(coding);
-
-        identifier.setValue("mbi-1");
+        Coding coding = setupCodingForTestingCurrencyTypeCode(MBI_ID_R4, "MB");
         
-        Extension extension = new Extension();
-        extension.setUrl("invalid_url");
-        Coding extCoding = new Coding();
-        extCoding.setSystem(CURRENCY_IDENTIFIER);
-        extCoding.setCode(CURRENT_MBI);
-        extension.setValue(extCoding);
-        identifier.getType().getCoding().get(0).addExtension(extension);
+        Coding extCoding = setupCodingForTestingCurrencyTypeCode(CURRENCY_IDENTIFIER, CURRENT_MBI);
+        Extension extension = setupExtensionForTestingCurrencyTypeCode("invalid_url", extCoding);
 
-        patient.setIdentifier(List.of(identifier));
+        Identifier identifier = setupIdentifierForTestingCurrencyTypeCode(coding, extension);
+        Patient patient = setupPatientForTestingCurrencyTypeCode(identifier);
 
         assertEquals(PatientIdentifier.Currency.UNKNOWN, IdentifierUtils.getCurrencyFromTypeCodingExtension(patient.getIdentifier().get(0)));
     }
@@ -446,6 +376,42 @@ class PatientIdentifierUtilsTest {
 
             */
         }
+    }
+
+    Extension setupExtensionForTestingCurrencyTypeCode(String url, Coding extCoding) {
+        Extension extension = new Extension();
+        extension.setUrl(url);
+
+        if (extCoding != null) {
+            extension.setValue(extCoding);
+        }
+        return extension;
+    }
+
+    Coding setupCodingForTestingCurrencyTypeCode(String system, String code) {
+        Coding coding = new Coding();
+        coding.setSystem(system);
+        coding.setCode(code);
+        return coding;
+    }
+
+    Identifier setupIdentifierForTestingCurrencyTypeCode(Coding coding, Extension extension) {
+        Identifier identifier = new Identifier();
+        identifier.setSystem(MBI_ID);
+        identifier.setValue("mbi-1");
+        if (coding != null) {
+            identifier.getType().addCoding(coding);
+        }
+        if (extension != null) {
+            identifier.getType().getCoding().get(0).addExtension(extension);
+        }
+        return identifier;
+    }
+
+    Patient setupPatientForTestingCurrencyTypeCode(Identifier identifier) {
+        Patient patient = new Patient();
+        patient.setIdentifier(List.of(identifier));
+        return patient;
     }
 
     IBaseResource extractBundle(FhirVersion version, String fileName) throws IOException {

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
@@ -308,17 +308,13 @@ class PatientIdentifierUtilsTest {
 
     @Test
     void testReturnsFalseIfCodingValid() {
-        String codeSystem = MBI_ID_R4;
-        String mbCodeValue = "MB";
-        assertFalse(IdentifierUtils.checkCodingIsNotValid(codeSystem, mbCodeValue));
-        String mcCodeValue = "MC";
-        assertFalse(IdentifierUtils.checkCodingIsNotValid(codeSystem, mcCodeValue));
+        assertFalse(IdentifierUtils.checkCodingIsNotValid(MBI_ID_R4, "MB"));
+        assertFalse(IdentifierUtils.checkCodingIsNotValid(MBI_ID_R4, "MC"));
     }
 
     @Test
     void testReturnsTrueIfExtensionsNotExists() {
-        List<IBaseExtension> extensions = new ArrayList<>();
-        assertTrue(IdentifierUtils.checkExtensionsNotExists(extensions));
+        assertTrue(IdentifierUtils.checkExtensionsNotExists(new ArrayList()<>));
     }
 
     @Test

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
@@ -408,7 +408,7 @@ class PatientIdentifierUtilsTest {
     }
 
     @Test
-    void testReturnsFalseIfURLInvalid() {
+    void testReturnsTrueIfURLInvalid() {
         String url = "invalid_url";
         assertTrue(IdentifierUtils.checkCurrencyUrlIsNotValid(url));
     }

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
@@ -303,9 +303,7 @@ class PatientIdentifierUtilsTest {
 
     @Test
     void testReturnsTrueIfCodingNotValid() {
-        String codeSystem = "invalid_system";
-        String codeValue = "invalid_value";
-        assertTrue(IdentifierUtils.checkCodingIsNotValid(codeSystem, codeValue));
+        assertTrue(IdentifierUtils.checkCodingIsNotValid("invalid_system", "invalid_value"));
     }
 
     @Test
@@ -333,14 +331,12 @@ class PatientIdentifierUtilsTest {
 
     @Test
     void testReturnsFalseIfURLValid() {
-        String url = IdentifierUtils.CURRENCY_IDENTIFIER;
-        assertFalse(IdentifierUtils.checkCurrencyUrlIsNotValid(url));
+        assertFalse(IdentifierUtils.checkCurrencyUrlIsNotValid(IdentifierUtils.CURRENCY_IDENTIFIER));
     }
 
     @Test
     void testReturnsTrueIfURLInvalid() {
-        String url = "invalid_url";
-        assertTrue(IdentifierUtils.checkCurrencyUrlIsNotValid(url));
+        assertTrue(IdentifierUtils.checkCurrencyUrlIsNotValid("invalid_url"));
     }
 
     @Test

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
@@ -20,6 +20,7 @@ import static gov.cms.ab2d.fhir.PatientIdentifier.Currency.CURRENT;
 import static gov.cms.ab2d.fhir.PatientIdentifier.Currency.HISTORIC;
 import static gov.cms.ab2d.fhir.PatientIdentifier.HISTORIC_MBI;
 import static gov.cms.ab2d.fhir.PatientIdentifier.MBI_ID;
+import static gov.cms.ab2d.fhir.PatientIdentifier.MBI_ID_R4;
 import static gov.cms.ab2d.fhir.IdentifierUtils.CURRENCY_IDENTIFIER;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
@@ -190,13 +191,39 @@ class PatientIdentifierUtilsTest {
         PatientIdentifier patientIdentifier = new PatientIdentifier();
         patientIdentifier.setType(PatientIdentifier.Type.MBI);
         patientIdentifier.setValue("test-1");
-        patientIdentifier.setCurrency(PatientIdentifier.Currency.UNKNOWN);
 
         Object type = Versions.invokeGetMethod(patientIdentifier, "getType");
-        List vals = (List) Versions.invokeGetMethod(type, "getCoding");
-        System.out.println("TEST-VALS = " + vals);
+        List vals = (List) Versions.invokeGetMethod(type, "getCode");
 
         assertFalse(IdentifierUtils.checkTypeAndCodingExists(type, vals));
+    }
+
+    @Test
+    void testReturnsFalseIfCodingInvalid() {
+        String codeSystem = "INVALID";
+        String codeValue = "INVALID";
+        assertFalse(IdentifierUtils.checkCodingIsValid(codeSystem, codeValue));
+    }
+
+    @Test
+    void testReturnsTrueIfCodingValid() {
+        String codeSystem = MBI_ID_R4;
+        String mbCodeValue = "MB";
+        assertTrue(IdentifierUtils.checkCodingIsValid(codeSystem, mbCodeValue));
+        String mcCodeValue = "MC";
+        assertTrue(IdentifierUtils.checkCodingIsValid(codeSystem, mcCodeValue));
+    }
+
+    @Test
+    void testReturnsTrueIfURLValid() {
+        String url = IdentifierUtils.CURRENCY_IDENTIFIER;
+        assertTrue(IdentifierUtils.checkCurrencyUrlIsValid(url));
+    }
+
+    @Test
+    void testReturnsFalseIfURLInvalid() {
+        String url = "INVALID";
+        assertFalse(IdentifierUtils.checkCurrencyUrlIsValid(url));
     }
 
     @Test

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
@@ -2,9 +2,10 @@ package gov.cms.ab2d.fhir;
 
 import org.hl7.fhir.dstu3.model.Bundle;
 import org.hl7.fhir.dstu3.model.Coding;
-import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.Identifier;
 import org.hl7.fhir.dstu3.model.Patient;
+import org.hl7.fhir.dstu3.model.Extension;
+import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.instance.model.api.ICompositeType;
 import org.junit.jupiter.api.Test;
@@ -13,6 +14,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Set;
 
 import static gov.cms.ab2d.fhir.PatientIdentifier.CURRENT_MBI;
@@ -358,43 +360,57 @@ class PatientIdentifierUtilsTest {
     }
 
     @Test
-    void testReturnsFalseIfCodingNotExist() {
+    void testReturnsTrueIfCodingNotExist() {
         PatientIdentifier patientIdentifier = new PatientIdentifier();
         patientIdentifier.setType(PatientIdentifier.Type.MBI);
         patientIdentifier.setValue("test-1");
 
         Object type = Versions.invokeGetMethod(patientIdentifier, "getType");
-        List vals = (List) Versions.invokeGetMethod(type, "getCode");
+        List<Coding> vals = (List) Versions.invokeGetMethod(type, "getCode");
 
-        assertFalse(IdentifierUtils.checkTypeAndCodingExists(type, vals));
+        assertTrue(IdentifierUtils.checkTypeAndCodingNotExists(type, vals));
     }
 
     @Test
-    void testReturnsFalseIfCodingInvalid() {
+    void testReturnsTrueIfCodingNotValid() {
         String codeSystem = "invalid_system";
         String codeValue = "invalid_value";
-        assertFalse(IdentifierUtils.checkCodingIsValid(codeSystem, codeValue));
+        assertTrue(IdentifierUtils.checkCodingIsNotValid(codeSystem, codeValue));
     }
 
     @Test
-    void testReturnsTrueIfCodingValid() {
+    void testReturnsFalseIfCodingValid() {
         String codeSystem = MBI_ID_R4;
         String mbCodeValue = "MB";
-        assertTrue(IdentifierUtils.checkCodingIsValid(codeSystem, mbCodeValue));
+        assertFalse(IdentifierUtils.checkCodingIsNotValid(codeSystem, mbCodeValue));
         String mcCodeValue = "MC";
-        assertTrue(IdentifierUtils.checkCodingIsValid(codeSystem, mcCodeValue));
+        assertFalse(IdentifierUtils.checkCodingIsNotValid(codeSystem, mcCodeValue));
     }
 
     @Test
-    void testReturnsTrueIfURLValid() {
+    void testReturnsTrueIfExtensionsNotExists() {
+        List<IBaseExtension> extensions = new ArrayList<>();
+        assertTrue(IdentifierUtils.checkExtensionsNotExists(extensions));
+    }
+
+    @Test
+    void testReturnsFalseIfExtensionsExists() {
+        List<IBaseExtension> extensions = new ArrayList<>();
+        Extension extension = new Extension();
+        extensions.add(extension);
+        assertFalse(IdentifierUtils.checkExtensionsNotExists(extensions));
+    }
+
+    @Test
+    void testReturnsFalseIfURLValid() {
         String url = IdentifierUtils.CURRENCY_IDENTIFIER;
-        assertTrue(IdentifierUtils.checkCurrencyUrlIsValid(url));
+        assertFalse(IdentifierUtils.checkCurrencyUrlIsNotValid(url));
     }
 
     @Test
     void testReturnsFalseIfURLInvalid() {
         String url = "invalid_url";
-        assertFalse(IdentifierUtils.checkCurrencyUrlIsValid(url));
+        assertTrue(IdentifierUtils.checkCurrencyUrlIsNotValid(url));
     }
 
     @Test

--- a/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
+++ b/ab2d-fhir/src/test/java/gov/cms/ab2d/fhir/PatientIdentifierUtilsTest.java
@@ -178,6 +178,28 @@ class PatientIdentifierUtilsTest {
     }
 
     @Test
+    void testGetCurrentMbiTypeNotExists() {
+        PatientIdentifier patientIdentifier = new PatientIdentifier();
+        patientIdentifier.setType(null);
+        patientIdentifier.setValue("test-1");
+        assertNull(IdentifierUtils.getCurrentMbi(List.of(patientIdentifier)));
+    }
+
+    @Test
+    void testReturnsFalseIfCodingNotExist() {
+        PatientIdentifier patientIdentifier = new PatientIdentifier();
+        patientIdentifier.setType(PatientIdentifier.Type.MBI);
+        patientIdentifier.setValue("test-1");
+        patientIdentifier.setCurrency(PatientIdentifier.Currency.UNKNOWN);
+
+        Object type = Versions.invokeGetMethod(patientIdentifier, "getType");
+        List vals = (List) Versions.invokeGetMethod(type, "getCoding");
+        System.out.println("TEST-VALS = " + vals);
+
+        assertFalse(IdentifierUtils.checkTypeAndCodingExists(type, vals));
+    }
+
+    @Test
     void testR4ExtractIds() throws IOException {
         List<String> beneIds = List.of("-19990000001101", "-19990000001102", "-19990000001103");
         List<String> currentMbis = List.of("3S24A00AA00", "4S24A00AA00", "5S24A00AA00");

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
             : System.getenv()['ARTIFACTORY_PASSWORD']
 
     // AB2D libraries
-    fhirVersion='1.2.6'
+    fhirVersion='1.2.7'
     bfdVersion='2.2.2'
     aggregatorVersion='1.3.4'
     filtersVersion='1.9.4'


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/AB2D-6101

## 🛠 Changes

Address code smell in IdentifierUtils, reducing single method complexity.
Add test cases to cover new utility methods created to break apart the above method.
Bumps fhir lib version to 1.2.7

## ℹ️ Context

This is part of an ongoing effort to pay down tech debt and increase the reliability and maintainability of AB2D's codebase. 

## 🧪 Validation

Tested locally and passing CI checks.