### PR TITLE
PLT-657:Rename the public platform github repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: 'corretto'
 
       - name: Set env vars from AWS params
-        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        uses: cmsgov/cdap/actions/aws-params-env-action@main
         with:
           params: |
             ARTIFACTORY_URL=/artifactory/url

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
           distribution: 'corretto'
 
       - name: Set env vars from AWS params
-        uses: cmsgov/ab2d-bcda-dpc-platform/actions/aws-params-env-action@main
+        uses: cmsgov/cdap/actions/aws-params-env-action@main
         with:
           params: |
             ARTIFACTORY_URL=/artifactory/url


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-657

## 🛠 Changes

references to ab2d-bcda-dpc-platform renamed to cdap

## ℹ️ Context

we are renaming the ab2d-bcda-dpc-platform repo to cda

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

upon approval, ab2d-bcda-dpc-platform repo will be renamed to cdap and workflow re-ran, if successful PR merged if not ab2d-bcda-dpc-platform repo rename to cdap reverted while investigating why workflow failed
